### PR TITLE
Use a dedicated transpiler for styled-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28197,6 +28197,15 @@
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
             "dev": true
         },
+        "ttypescript": {
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+            "integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+            "dev": true,
+            "requires": {
+                "resolve": ">=1.9.0"
+            }
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -28268,6 +28277,12 @@
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
             "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "dev": true
+        },
+        "typescript-plugin-styled-components": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.5.0.tgz",
+            "integrity": "sha512-5x/30WvzlrD0h5MOlp/pFVQFNWCupeG6QqHvsYlsg9Qg1hxG614kf3p4FmgJ35UxKz0mREX7+4S1Li46gsM3eQ==",
             "dev": true
         },
         "typography-breakpoint-constants": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "scripts": {
         "clean": "rm -rf lib",
         "build": "npm run clean && npm run build:cjs && npm run build:esm",
-        "build:cjs": "tsc --target es5 --module commonjs --outDir lib/cjs",
-        "build:esm": "tsc --target es6 --module esnext --outDir lib/esm",
+        "build:cjs": "ttsc --target es5 --module commonjs --outDir lib/cjs",
+        "build:esm": "ttsc --target es6 --module esnext --outDir lib/esm",
         "build:documentation": "docz build",
         "generate": "npm run generate:icons",
         "generate:icons": "node ./scripts/generate-icons assets/icons -r -o src/icons --exclude-color-prop **/payment/** **/flags/** --exclude-suffix **/flags/**",
@@ -92,7 +92,9 @@
         "tslint-no-circular-imports": "^0.7.0",
         "tslint-react": "^4.2.0",
         "tslint-react-hooks": "^2.2.2",
+        "ttypescript": "^1.5.12",
         "typescript": "^3.8.3",
+        "typescript-plugin-styled-components": "^1.5.0",
         "yargs": "^15.3.1"
     },
     "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,14 @@
         "declaration": true,
         "declarationDir": "lib/types/",
         "rootDir": "src/",
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "plugins": [
+            {
+                "transform": "typescript-plugin-styled-components",
+                "type": "config",
+                "ssr": true
+            }
+        ]
     },
     "include": ["src/**/*"],
     "exclude": ["src/**/docs"]


### PR DESCRIPTION
At the moment we use standard TypeScript transpiler for styled-components. In that setup server-side rendering does not work as expected.

The PR uses the approach mentioned in the styled-components documentation