### PR TITLE
docs(contributing): remove references to internal systems

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -8,17 +8,15 @@ import { ImageModal } from './components/ImageModal.tsx';
 import { TitleCard } from './components/TitleCard';
 
 <TitleCard title="Contributing">
-    Everyone at FREE NOW is welcome to make contributions to the design system. To make sure that everyone can contribute,
+    Everyone is welcome to make contributions to the design system. To make sure that everyone can contribute,
     we have decided to write out a few steps that help you add your contributions.
 </TitleCard>
 
 ## Reporting Bugs
 
 The design system is used in many places. We have a hard time keeping our eyes on all of them to keep up with the issues
-you’re having. If you see something amiss, please report it via a [Jira issue](https://jira.intapps.it/secure/CreateIssue!default.jspa)
-in the "Wave Design System" project so we have insight in order to resolve it.
-
-If you are unsure if what you found is a bug, feel free to ask in the #ask-wave Slack channel for advice.
+you’re having. If you see something amiss, please [create a Github issue](https://github.com/freenowtech/wave/issues/new)
+so we have insight in order to resolve it.
 
 ## Submitting Components
 
@@ -32,25 +30,20 @@ should be added to the design system.
 
 This is the submission process for new components, essentials and improvements to existing components:
 
-1. [Create a Jira issue](https://jira.intapps.it/secure/CreateIssue!default.jspa) in the "Wave Design System" with the
-basic information and gather feedback from the maintainers and your fellow developers in the #ask-wave Slack channel
-1. Ask the design team to create a design for the component and publish it to the Design System project in Zeplin
-1. Align with the maintainers and other developers on the API of the component
-4. Move the issue into the "Ready for Development" status and you or another developer can now start building
-5. After the development is done, open a pull request, keeping the
-[development guidelines](https://stash.intapps.it/projects/DS/repos/wave/browse/CONTRIBUTING.md) in mind. You will get
-feedback here, but we recommend check-ins with designers and developers during the development
-6. With the required approvals (2 from development and 1 from design), you can merge your branch to master and it will be
-released by the maintainers in the next version of `@freenow/wave`
+1. [Create a Github issue](https://github.com/freenowtech/wave/issues/new) with the basic information and gather
+feedback from the maintainers and your fellow developers
+2. Align with the maintainers and other developers on the API of the component
+3. After the development is done, open a pull request, keeping the
+[development guidelines](../CONTRIBUTING.md) in mind. You will get feedback here, but we recommend check-ins with 
+esigners and developers during the development
+4. With the required approvals, you can merge your branch to master and it will be released by the maintainers in the
+next version of `@freenow/wave`
 
-If you need any help during the process, don't hesitate to reach out to one of the maintainers or the #ask-wave
-Slack channel.
+If you need any help during the process, don't hesitate to reach out to one of the maintainers.
 
 ### Roadmap
 
-If you're looking for something to work on, a great place to start is our [issues labeled up for grabs](https://jira.intapps.it/issues/?jql=project%20%3D%20%22Wave%20Design%20System%22%20AND%20status%20%3D%20%22Ready%20for%20Development%22%20ORDER%20BY%20Rang%20)!
-If you've got a feature that you'd like to implement, be sure to check out the Jira Board to make sure it hasn't already
-been started on.
+If you're looking for something to work on, a great place to start is our [issues labeled "help wanted"](https://github.com/freenowtech/wave/labels/help%20wanted)!
 
 ## Improve Documentation
 
@@ -66,4 +59,4 @@ All the documentation pages are Markdown-based. You don't need to know how to wr
 ## Other Contributions
 
 Not all contributions have to be made in design, code and pull requests. You can for example help your team adopt the
-design system components or answer questions in the #ask-wave channel your fellow developers might be having.
+design system components or answer questions in issues or discussions.


### PR DESCRIPTION
I reworded some parts of the contribution guide because it made references to the internal systems.