### PR TITLE
docs: removed some pages and internal references

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -55,8 +55,3 @@ module.exports = {
 
 We've decided to use dynamic imports to better support tree shaking and reduce the bundle
 size this library will take up in your project.
-
-## Questions?
-
-Have questions? Join us in [#ask-wave](https://mytaxi.slack.com/archives/CLM50RECU)
-on slack, we're always happy to help.

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,7 +1,15 @@
 export default {
     title: `Wave`,
     menu: ['Get Started', 'Releases', 'Contributing', 'Essentials', 'Components'],
-    ignore: ['CONTRIBUTING.md', 'RELEASING.md', 'README.md', 'fixtures/**/*.md', '.idea/**/*'],
+    ignore: [
+        'CONTRIBUTING.md',
+        'RELEASING.md',
+        'README.md',
+        'SECURITY.md',
+        'MAINTAINERS.md',
+        'fixtures/**/*.md',
+        '.idea/**/*'
+    ],
     propsParser: false,
     typescript: true,
     repository: false


### PR DESCRIPTION
Removed SECURITY and MAINTAINERS page which were added
accidentally, as well as a link to intenal slack.