### PR TITLE
Refactor/adapt selectlist style

### DIFF
--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -1,9 +1,8 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { FC } from 'react';
 import ReactSelect, { components as ReactSelectComponents, IndicatorProps, Props, StylesConfig } from 'react-select';
-import { MarginProps, style, WidthProps } from 'styled-system';
+import { MarginProps, WidthProps } from 'styled-system';
 
 import { Colors, Elevation } from '../../essentials';
-import { theme } from '../../essentials/theme';
 import { ChevronDownIcon, ChevronUpIcon, CloseIcon } from '../../icons';
 import {
     ClassNameProps,

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useRef, useState } from 'react';
 import ReactSelect, { components as ReactSelectComponents, IndicatorProps, Props, StylesConfig } from 'react-select';
-import { MarginProps, WidthProps } from 'styled-system';
+import { MarginProps, style, WidthProps } from 'styled-system';
 
 import { Colors, Elevation } from '../../essentials';
 import { theme } from '../../essentials/theme';
@@ -131,21 +131,41 @@ const customStyles: StylesConfig = {
             ...disabled
         };
     },
-    option: (provided, state) => ({
-        ...provided,
-        color: state.isSelected ? Colors.WHITE : Colors.AUTHENTIC_BLUE_900,
-        padding: '0.375rem 0.75rem',
-        fontSize: 'inherit',
-        backgroundColor: state.isSelected
-            ? Colors.ACTION_BLUE_900
-            : state.isFocused
-            ? Colors.AUTHENTIC_BLUE_50
-            : Colors.WHITE,
-        '&:active': {
-            background: state.isSelected ? Colors.ACTION_BLUE_900 : Colors.AUTHENTIC_BLUE_50
-        },
-        wordWrap: 'break-word'
-    }),
+    option: (provided, state) => {
+        const colorsByState = {
+            isDisabled: {
+                color: Colors.AUTHENTIC_BLUE_350
+            },
+            isFocused: {
+                backgroundColor: Colors.ACTION_BLUE_50
+            },
+            isSelected: {
+                backgroundColor: Colors.ACTION_BLUE_900,
+                color: Colors.WHITE
+            }
+        };
+
+        const defaultColors = {
+            color: Colors.AUTHENTIC_BLUE_900,
+            backgroundColor: Colors.WHITE
+        };
+
+        const colors = Object.keys(colorsByState)
+            .filter(key => state[key])
+            .reduce((acc, style) => ({ ...acc, ...colorsByState[style] }), defaultColors);
+
+        return {
+            ...provided,
+            ...colors,
+            '&:active': {
+                ...colors
+            },
+            padding: `${state.selectProps.size === 'medium' ? '0.5rem' : '0.375rem'} 0.75rem`,
+            fontSize: 'inherit',
+            wordWrap: 'break-word',
+            cursor: state.isDisabled ? 'not-allowed' : 'default'
+        };
+    },
     multiValue: (provided, { selectProps }) => {
         const styles = {
             ...provided,

--- a/src/components/SelectList/docs/SelectList.mdx
+++ b/src/components/SelectList/docs/SelectList.mdx
@@ -54,7 +54,8 @@ The following properties have been disabled since they aren't supported by this 
             },
             {
                 label: "Paris",
-                value: "par"
+                value: "par",
+                isDisabled: true 
             }
         ]}
     />


### PR DESCRIPTION
**What**
This PR aims to adapt the `SelectList` component style to the given [design](https://app.zeplin.io/project/57fe438f81b870887cc71736/screen/605c7840aebc4544301abe77)

**How**
Update the color of the selected items and add the style for the disabled options.
Update the example showing the disabled options.

* feat: add disabled option style
* refactor: apply updated design
<img width="396" alt="Screenshot 2021-04-20 at 16 15 01" src="https://user-images.githubusercontent.com/12762609/115851689-852e0e80-a427-11eb-92b8-6410badcb71e.png">
<img width="408" alt="Screenshot 2021-04-20 at 16 13 57" src="https://user-images.githubusercontent.com/12762609/115851704-8828ff00-a427-11eb-9630-5b35e139852e.png">
