### PR TITLE
fix: isLastPage true if 0 items

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -105,7 +105,7 @@ const Pagination: React.FC<PaginationProps> = ({
     onSkipBackward
 }) => {
     const isFirstPage = value === 1;
-    const isLastPage = value === Math.ceil(totalItems / pageSize);
+    const isLastPage = value === Math.ceil(totalItems / pageSize) || !totalItems;
 
     return (
         <Container>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -105,7 +105,7 @@ const Pagination: React.FC<PaginationProps> = ({
     onSkipBackward
 }) => {
     const isFirstPage = value === 1;
-    const isLastPage = value === Math.ceil(totalItems / pageSize) || !totalItems;
+    const isLastPage = totalItems > 0 && pageSize > 0 ? value === Math.ceil(totalItems / pageSize) : false;
 
     return (
         <Container>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -105,7 +105,7 @@ const Pagination: React.FC<PaginationProps> = ({
     onSkipBackward
 }) => {
     const isFirstPage = value === 1;
-    const isLastPage = totalItems > 0 && pageSize > 0 ? value === Math.ceil(totalItems / pageSize) : false;
+    const isLastPage = totalItems > 0 ? value === Math.ceil(totalItems / pageSize) : true;
 
     return (
         <Container>


### PR DESCRIPTION
**What**
When the `Pagination` component gets 0 items "nextPage" and "skipToLastPage" buttons are not disabled.

**Why**
When the component gets 0 items `isLastPage` is never true, because `totalItems / pageSize` with `totalItems === 0` gives `0` and `value` (the current page) must be `>= 1`.

**How**
In the case we don't have items `!totalItems`, then `isLastPage` is set to true.

<img width="363" alt="Screenshot 2021-05-05 at 11 33 21" src="https://user-images.githubusercontent.com/12762609/117122125-d3cb9900-ad95-11eb-8458-d9e21528ec15.png">
