### PR TITLE
Update select component "disabled"

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -13,6 +13,9 @@ import { TitleCard } from './components/TitleCard';
 - `Checkbox` small & medium variants have been introduced
 - `SelectList` suggestions list applies the given design (add disabled style)
 
+#### 🐛 Bug Fixes
+- `Select` to have cursor pointer not-allowed
+
 
 #### 📖 Documentation
 - Extend documentation for `Checkbox` with PropsTable

--- a/src/components/Select/Select.spec.tsx
+++ b/src/components/Select/Select.spec.tsx
@@ -8,6 +8,19 @@ describe('Select', () => {
         expect(render(<Select />).container.firstChild).toMatchSnapshot();
     });
 
+    it('can be selected using accessible queries', () => {
+        render(
+            <Select defaultValue="2" label="Wave" id="test">
+                <option value="1">test 1</option>
+                <option value="2">test 2</option>
+            </Select>
+        );
+
+        userEvent.selectOptions(screen.getByRole('combobox', { name: /wave/i }), '1');
+
+        expect(screen.getByLabelText('Wave')).toHaveDisplayValue('test 1');
+    });
+
     describe('variant "boxed"', () => {
         it('renders with default props', () => {
             expect(render(<Select variant="boxed" />).container.firstChild).toMatchSnapshot();
@@ -90,20 +103,6 @@ describe('Select', () => {
                     </Select>
                 ).container.firstChild
             ).toMatchSnapshot();
-        });
-
-        // this test gets used to visualize testing in the docs, please update docs in case of updating the test
-        it('can be selected by label', () => {
-            render(
-                <Select defaultValue="2" label="Example" id="test">
-                    <option value="1">test 1</option>
-                    <option value="2">test 2</option>
-                </Select>
-            );
-
-            userEvent.selectOptions(screen.getByLabelText('Example'), '1');
-
-            expect(screen.getByLabelText('Example')).toHaveDisplayValue('test 1');
         });
     });
 });

--- a/src/components/Select/SelectInput.ts
+++ b/src/components/Select/SelectInput.ts
@@ -70,6 +70,7 @@ const getErrorStyles = ({ error, variant: variantProp }: BaseSelectProps) => {
 
 const disabledStyles = css<BaseSelectProps>`
     color: ${p => (p.inverted ? Colors.AUTHENTIC_BLUE_550 : Colors.AUTHENTIC_BLUE_200)};
+    cursor: not-allowed;
     border-color: ${p => (p.inverted ? Colors.AUTHENTIC_BLUE_550 : Colors.AUTHENTIC_BLUE_200)};
 
     & ~ ${SelectLabel} {

--- a/src/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -287,6 +287,7 @@ exports[`Select variant "bottom-lined" renders the disabled styles 1`] = `
   height: 3.5rem;
   padding: 1.25rem 1.75rem 0.25rem 0.25rem;
   color: #C6CDD4;
+  cursor: not-allowed;
   border-color: #C6CDD4;
 }
 
@@ -584,6 +585,7 @@ exports[`Select variant "bottom-lined" renders the inverted disabled styles 1`] 
   height: 3.5rem;
   padding: 1.25rem 1.75rem 0.25rem 0.25rem;
   color: #637689;
+  cursor: not-allowed;
   border-color: #637689;
 }
 
@@ -1267,6 +1269,7 @@ exports[`Select variant "boxed" renders the disabled styles 1`] = `
   height: 3rem;
   padding: 0 2.25rem 0 0.75rem;
   color: #C6CDD4;
+  cursor: not-allowed;
   border-color: #C6CDD4;
 }
 
@@ -1552,6 +1555,7 @@ exports[`Select variant "boxed" renders the inverted disabled styles 1`] = `
   height: 3rem;
   padding: 0 2.25rem 0 0.75rem;
   color: #637689;
+  cursor: not-allowed;
   border-color: #637689;
 }
 


### PR DESCRIPTION
**What:**
Mimic input disabled styles on select component
​
**Why:**
Closes #21 
​
**How:**
Add missing style. "cursor `not-allowed`"
​
**Media:**
https://www.loom.com/share/52b30cf3842e46d4a0d9b5326bccc7cf

**Checklist:**
- [x] Release notes added [Release notes](../docs/release-notes.mdx)
- [x] Ready to be merged