### PR TITLE
fix: use default export instead of named export

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { default as React, forwardRef, useEffect, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { extractClassNameProps, extractWidthProps, extractWrapperMarginProps } from '../../utils/extractProps';
 import { BottomLinedInput } from './BottomLinedInput';
 import { BottomLinedInputLabel } from './BottomLinedInputLabel';

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,4 +1,4 @@
-import { default as React, FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import styled, { CSSProperties } from 'styled-components';
 
 import { compose, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system';


### PR DESCRIPTION
**What:**
During the investigation of #71 we noticed that `Input` and `Textarea` don't render on codesandbox. This affects only users of the ESM version of the library.
​
**Why:**
Fixes a potentially live bug.
​
**How:**
Both components used a named import for `React` by using `import { default as React } from "react"`. I changed this to `import React from "react"`.

- [X] Ready to be merged
