### PR TITLE
Allow textAlign on TableCell components

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -12,6 +12,7 @@ import { TitleCard } from './components/TitleCard';
 #### 💅 Enhancements
 - `Checkbox` small & medium variants have been introduced
 - `SelectList` suggestions list applies the given design (add disabled style)
+- `TableCell` allow to set `textAlign`
 
 #### 🐛 Bug Fixes
 - `Select` to have cursor pointer not-allowed

--- a/src/components/Table/components/TableCell.tsx
+++ b/src/components/Table/components/TableCell.tsx
@@ -1,10 +1,12 @@
 import React, { DetailedHTMLProps, TableHTMLAttributes, TdHTMLAttributes, useContext } from 'react';
 import styled from 'styled-components';
+import { compose, textAlign, TextAlignProps } from 'styled-system';
 import { TableContext } from '../context/TableContext';
 import { TableProps } from './Table';
 
 type TableCellProps = Pick<TableProps, 'rowSize' | 'columnSpace'> &
-    Omit<DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>, 'ref'>;
+    Omit<DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>, 'ref'> &
+    TextAlignProps;
 
 const TableCellElement = styled.td<TableCellProps>`
     height: ${p => p.rowSize};
@@ -19,6 +21,8 @@ const TableCellElement = styled.td<TableCellProps>`
     &:last-child {
         padding-right: ${p => p.columnSpace};
     }
+
+    ${compose(textAlign)}
 `;
 
 const TableCell = props => {

--- a/src/components/Table/components/TableHeaderCell.tsx
+++ b/src/components/Table/components/TableHeaderCell.tsx
@@ -16,6 +16,7 @@ const TableHeaderCellElement = styled.th.attrs({ theme })<TableHeaderCellProps>`
     font-weight: ${get('fontWeights.bold')};
     height: ${p => p.rowSize};
     padding: 0 calc(${p => p.columnSpace} / 2);
+    text-align: left;
     vertical-align: middle;
     white-space: nowrap;
 

--- a/src/components/Table/components/TableHeaderCell.tsx
+++ b/src/components/Table/components/TableHeaderCell.tsx
@@ -1,5 +1,6 @@
 import React, { DetailedHTMLProps, ThHTMLAttributes, useContext } from 'react';
 import styled from 'styled-components';
+import { compose, textAlign, TextAlignProps } from 'styled-system';
 import { Colors } from '../../../essentials';
 import { theme } from '../../../essentials/theme';
 import { get } from '../../../utils/themeGet';
@@ -7,13 +8,13 @@ import { TableContext } from '../context/TableContext';
 import { TableProps } from './Table';
 
 type TableHeaderCellProps = Pick<TableProps, 'rowSize' | 'columnSpace'> &
-    DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
+    DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> &
+    TextAlignProps;
 
 const TableHeaderCellElement = styled.th.attrs({ theme })<TableHeaderCellProps>`
-    height: ${p => p.rowSize};
-    text-align: left;
-    font-weight: ${get('fontWeights.bold')};
     border-bottom: 0.0625rem solid ${Colors.AUTHENTIC_BLUE_550} !important;
+    font-weight: ${get('fontWeights.bold')};
+    height: ${p => p.rowSize};
     padding: 0 calc(${p => p.columnSpace} / 2);
     vertical-align: middle;
     white-space: nowrap;
@@ -25,6 +26,8 @@ const TableHeaderCellElement = styled.th.attrs({ theme })<TableHeaderCellProps>`
     &:last-child {
         padding-right: ${p => p.columnSpace};
     }
+
+    ${compose(textAlign)}
 `;
 
 const TableHeaderCell = props => {


### PR DESCRIPTION
**What:**
Add textAlign prop to `TableCell` and `TableCellHeader` components
​
**Why:**
closes #70 
​
**How:**
Use styled-system API and compose components with textAlign
​
**Media:**
![image](https://user-images.githubusercontent.com/1425162/118107536-27199900-b3df-11eb-8869-b2634670eea3.png)

**Checklist:**
- [x] Release notes added
- [x] Ready to be merged