### PR TITLE
Inline spinner update

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -15,6 +15,7 @@ import { TitleCard } from './components/TitleCard';
 
 #### 🐛 Bug Fixes
 - `Select` to have cursor pointer not-allowed
+- `InlineSpinner` to behave closer to other icons when placed alongside text
 
 
 #### 📖 Documentation

--- a/src/components/InlineSpinner/InlineSpinner.tsx
+++ b/src/components/InlineSpinner/InlineSpinner.tsx
@@ -36,7 +36,7 @@ const rotation = keyframes`
     }
 `;
 
-const InlineSpinner: React.FC<InlineSpinnerProps> = styled.div<InlineSpinnerProps>`
+const InlineSpinnerIcon: React.FC<InlineSpinnerProps> = styled.div<InlineSpinnerProps>`
     display: inline-block;
     box-sizing: border-box;
     width: 1.25rem;
@@ -49,6 +49,12 @@ const InlineSpinner: React.FC<InlineSpinnerProps> = styled.div<InlineSpinnerProp
 
     ${compose(margin, sizeVariant)}
 `;
+
+const InlineSpinner = () => (
+    <span>
+        <InlineSpinnerIcon />
+    </span>
+);
 
 InlineSpinner.defaultProps = {
     color: Colors.AUTHENTIC_BLUE_900,

--- a/src/components/InlineSpinner/__snapshots__/InlineSpinner.spec.tsx.snap
+++ b/src/components/InlineSpinner/__snapshots__/InlineSpinner.spec.tsx.snap
@@ -7,20 +7,18 @@ exports[`InlineSpinner renders in a custom color 1`] = `
   width: 1.25rem;
   height: 1.25rem;
   vertical-align: text-bottom;
-  border: 0.125rem solid #069D4F;
+  border: 0.125rem solid;
   border-right-color: transparent;
   border-radius: 50%;
   -webkit-animation: wdnds 750ms linear infinite;
   animation: wdnds 750ms linear infinite;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-width: 0.125rem;
 }
 
-<div
-  class="c0"
-  color="#069D4F"
-/>
+<span>
+  <div
+    class="c0"
+  />
+</span>
 `;
 
 exports[`InlineSpinner renders the default variant 1`] = `
@@ -30,20 +28,18 @@ exports[`InlineSpinner renders the default variant 1`] = `
   width: 1.25rem;
   height: 1.25rem;
   vertical-align: text-bottom;
-  border: 0.125rem solid #001E3E;
+  border: 0.125rem solid;
   border-right-color: transparent;
   border-radius: 50%;
   -webkit-animation: wdnds 750ms linear infinite;
   animation: wdnds 750ms linear infinite;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-width: 0.125rem;
 }
 
-<div
-  class="c0"
-  color="#001E3E"
-/>
+<span>
+  <div
+    class="c0"
+  />
+</span>
 `;
 
 exports[`InlineSpinner renders the small size 1`] = `
@@ -53,18 +49,16 @@ exports[`InlineSpinner renders the small size 1`] = `
   width: 1.25rem;
   height: 1.25rem;
   vertical-align: text-bottom;
-  border: 0.125rem solid #001E3E;
+  border: 0.125rem solid;
   border-right-color: transparent;
   border-radius: 50%;
   -webkit-animation: wdnds 750ms linear infinite;
   animation: wdnds 750ms linear infinite;
-  width: 1rem;
-  height: 1rem;
-  border-width: 0.1rem;
 }
 
-<div
-  class="c0"
-  color="#001E3E"
-/>
+<span>
+  <div
+    class="c0"
+  />
+</span>
 `;


### PR DESCRIPTION
**What:**
Allow `InlineSpinner` to render as other icons when placed alongside a text
​
**Why:**
Relates #22 

In some cases when the spinner is being rendered with text it breaks the layout
​
**How:**
Wrap the icon with `span` _(as changing the div with span doesn't solve the issue)_ so we can reproduce the scenario similar to https://codesandbox.io/s/button-spinner-issue-wnmgv?file=/src/App.tsx

**Checklist:**
- [x] Release notes added
- [x] Ready to be merged

**Note:**
_I am a bit hesitant with the approach but at the same time I think It will solve the issue and there is no clear drawbacks I can see_