### PR TITLE
Update label background for boxed input variant

### DIFF
--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -16,6 +16,7 @@ import { TitleCard } from './components/TitleCard';
 
 #### 🐛 Bug Fixes
 - `Select` to have cursor pointer not-allowed
+- `Input` boxed variant label respect host background color
 
 
 #### 📖 Documentation

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -16,7 +16,6 @@ import { TitleCard } from './components/TitleCard';
 
 #### 🐛 Bug Fixes
 - `Select` to have cursor pointer not-allowed
-- `Input` boxed variant label respect host background color
 
 
 #### 📖 Documentation

--- a/src/components/Datepicker/__snapshots__/DatepickerRangeInput.spec.tsx.snap
+++ b/src/components/Datepicker/__snapshots__/DatepickerRangeInput.spec.tsx.snap
@@ -80,6 +80,7 @@ exports[`DatepickerRangeInput renders the default props 1`] = `
 .c2 + .sc-AxgMl {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c2:disabled + .sc-AxgMl {
@@ -101,6 +102,7 @@ exports[`DatepickerRangeInput renders the default props 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1 {

--- a/src/components/Datepicker/__snapshots__/DatepickerSingleInput.spec.tsx.snap
+++ b/src/components/Datepicker/__snapshots__/DatepickerSingleInput.spec.tsx.snap
@@ -80,6 +80,7 @@ exports[`DatepickerSingleInput renders the default props 1`] = `
 .c1 + .sc-AxhUy {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .sc-AxhUy {
@@ -101,6 +102,7 @@ exports[`DatepickerSingleInput renders the default props 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {

--- a/src/components/Input/BoxedInput.ts
+++ b/src/components/Input/BoxedInput.ts
@@ -47,6 +47,11 @@ const BoxedInput: FC<InternalInputComponentProps> = styled(BaseInput)`
         ${p => (p.hasValue || p.placeholder ? activeBoxedPosition(p.size) : null)};
         color: ${getLabelColor};
         background: ${p => (p.inverted ? Colors.AUTHENTIC_BLUE_900 : Colors.WHITE)};
+        background: ${p =>
+            `linear-gradient(0deg, ${p.inverted ? Colors.AUTHENTIC_BLUE_900 : Colors.WHITE} calc(50% + ${
+                // @ts-ignore
+                p.size === 'small' ? '0.0825rem' : '0.0625rem'
+            }), transparent 50%)`};
     }
 
     ${p => (p.error ? errorStyles : null)}
@@ -71,6 +76,11 @@ const BoxedInput: FC<InternalInputComponentProps> = styled(BaseInput)`
             ${p => activeBoxedPosition(p.size)};
             color: ${p => (p.inverted ? Colors.WHITE : Colors.ACTION_BLUE_900)};
             background: ${p => (p.inverted ? Colors.AUTHENTIC_BLUE_900 : Colors.WHITE)};
+            background: ${p =>
+                `linear-gradient(0deg, ${p.inverted ? Colors.AUTHENTIC_BLUE_900 : Colors.WHITE} calc(50% + ${
+                    // @ts-ignore
+                    p.size === 'small' ? '0.0825rem' : '0.0625rem'
+                }), transparent 50%)`};
         }
     }
 `;

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -97,6 +97,7 @@ exports[`Input should set the htmlFor attribute for the label 1`] = `
 .c1 + .c2 {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .c2 {
@@ -118,6 +119,7 @@ exports[`Input should set the htmlFor attribute for the label 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {
@@ -1156,6 +1158,7 @@ exports[`Input variant "boxed" renders 1`] = `
 .c1 + .sc-AxhUy {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .sc-AxhUy {
@@ -1177,6 +1180,7 @@ exports[`Input variant "boxed" renders 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {
@@ -1277,6 +1281,7 @@ exports[`Input variant "boxed" renders the error state 1`] = `
 .c1 + .sc-AxhUy {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1 ~ .sc-AxhUy {
@@ -1302,6 +1307,7 @@ exports[`Input variant "boxed" renders the error state 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {
@@ -1422,6 +1428,7 @@ exports[`Input variant "boxed" renders the error state with label and placeholde
   font-size: 0.75rem;
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1 ~ .c2 {
@@ -1447,6 +1454,7 @@ exports[`Input variant "boxed" renders the error state with label and placeholde
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {
@@ -1551,6 +1559,7 @@ exports[`Input variant "boxed" renders the inverted style 1`] = `
 .c1 + .sc-AxhUy {
   color: #C6CDD4;
   background: #001E3E;
+  background: linear-gradient(0deg,#001E3E calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .sc-AxhUy {
@@ -1572,6 +1581,7 @@ exports[`Input variant "boxed" renders the inverted style 1`] = `
   font-size: 0.75rem;
   color: #FFFFFF;
   background: #001E3E;
+  background: linear-gradient(0deg,#001E3E calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {
@@ -1687,6 +1697,7 @@ exports[`Input variant "boxed" renders the label 1`] = `
 .c1 + .c2 {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .c2 {
@@ -1708,6 +1719,7 @@ exports[`Input variant "boxed" renders the label 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {
@@ -1831,6 +1843,7 @@ exports[`Input variant "boxed" renders the label and the placeholder 1`] = `
   font-size: 0.75rem;
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .c2 {
@@ -1852,6 +1865,7 @@ exports[`Input variant "boxed" renders the label and the placeholder 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c0 {
@@ -1956,6 +1970,7 @@ exports[`Input variant "boxed" renders the small size 1`] = `
 .c1 + .sc-AxhUy {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0825rem),transparent 50%);
 }
 
 .c1:disabled + .sc-AxhUy {
@@ -1977,6 +1992,7 @@ exports[`Input variant "boxed" renders the small size 1`] = `
   font-size: 0.625rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0825rem),transparent 50%);
 }
 
 .c0 {

--- a/src/components/Textarea/__snapshots__/Textarea.spec.tsx.snap
+++ b/src/components/Textarea/__snapshots__/Textarea.spec.tsx.snap
@@ -92,6 +92,7 @@ exports[`Textarea renders 1`] = `
 .c1 + .sc-AxiKw {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .sc-AxiKw {
@@ -113,6 +114,7 @@ exports[`Textarea renders 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div
@@ -236,6 +238,7 @@ exports[`Textarea renders the disabled state with label and placeholder 1`] = `
   font-size: 0.75rem;
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .c2 {
@@ -257,6 +260,7 @@ exports[`Textarea renders the disabled state with label and placeholder 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div
@@ -369,6 +373,7 @@ exports[`Textarea renders the error state 1`] = `
 .c1 + .sc-AxiKw {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1 ~ .sc-AxiKw {
@@ -394,6 +399,7 @@ exports[`Textarea renders the error state 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div
@@ -519,6 +525,7 @@ exports[`Textarea renders the error state with label and placeholder 1`] = `
   font-size: 0.75rem;
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1 ~ .c2 {
@@ -544,6 +551,7 @@ exports[`Textarea renders the error state with label and placeholder 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div
@@ -653,6 +661,7 @@ exports[`Textarea renders the inverted style 1`] = `
 .c1 + .sc-AxiKw {
   color: #C6CDD4;
   background: #001E3E;
+  background: linear-gradient(0deg,#001E3E calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .sc-AxiKw {
@@ -674,6 +683,7 @@ exports[`Textarea renders the inverted style 1`] = `
   font-size: 0.75rem;
   color: #FFFFFF;
   background: #001E3E;
+  background: linear-gradient(0deg,#001E3E calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div
@@ -794,6 +804,7 @@ exports[`Textarea renders the label 1`] = `
 .c1 + .c2 {
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .c2 {
@@ -815,6 +826,7 @@ exports[`Textarea renders the label 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div
@@ -943,6 +955,7 @@ exports[`Textarea renders the label and the placeholder 1`] = `
   font-size: 0.75rem;
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .c2 {
@@ -964,6 +977,7 @@ exports[`Textarea renders the label and the placeholder 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div
@@ -1095,6 +1109,7 @@ exports[`Textarea renders with custom height and width 1`] = `
   font-size: 0.75rem;
   color: #9CA7B4;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 .c1:disabled + .c2 {
@@ -1116,6 +1131,7 @@ exports[`Textarea renders with custom height and width 1`] = `
   font-size: 0.75rem;
   color: #096BDB;
   background: #FFFFFF;
+  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
 }
 
 <div


### PR DESCRIPTION
**What:**
Allow label background to "respect" host background-color
​
**Why:**
Closes #14​

**How:**
Apply a gradient of 50%/50% that will take half of the label + _(hardcoded value check note [1])_

**Media:**
![image](https://user-images.githubusercontent.com/1425162/118121932-71584580-b3f2-11eb-8a1a-183dff86017e.png)
![image](https://user-images.githubusercontent.com/1425162/118121938-73ba9f80-b3f2-11eb-9009-17a561b1a9df.png)
![image](https://user-images.githubusercontent.com/1425162/118121945-75846300-b3f2-11eb-93a8-70164a535610.png)

**Checklist:**
- [x] Release notes added
- [x] Ready to be merged

**Note:**
1. There are two variables taking place here. `fontSize`, `top` both of them change with the `size` attribute and the units themselves are odd numbers `0.375rem` or `0.75rem` this makes it harder to create a deterministic number instead of a "magic" one. The normal variant size medium will work great with `0.0625rem` matching the inset value but once the size small take place _I got confused_
2. I have a `TS` issue in regards to the prop.size in which the value is not mapped to `small` | `medium`

> Any suggestions/help to fix or improve these two points above is welcome. For now, these changes don't break anything and will solve the issue

Props to @nlopin for the gradient idea! 🚀 