### PR TITLE
Uses correct blur-radius value for medium size shadow

### DIFF
--- a/src/essentials/theme.ts
+++ b/src/essentials/theme.ts
@@ -25,7 +25,7 @@ const theme = {
     },
     shadows: {
         small: '0 0.0625rem 0.25rem 0 rgba(0,0,0,0.1)',
-        medium: '0 0 1rem 0.1875rem rgba(0,0,0,0.08)',
+        medium: '0 0 0.5rem 0.1875rem rgba(0,0,0,0.08)',
         large: '0 0 0.75rem 0.25rem rgba(0,0,0,0.12)'
     }
 };


### PR DESCRIPTION
**What:**
Align theme shadows scale to the initial design
​
**Why:**
Fixes #82


**Media:**
![Group 4](https://user-images.githubusercontent.com/1469636/118673812-989b8200-b7f9-11eb-875f-7d3fa7db6a5e.png)

**Checklist:**

- [ ] Release notes added [Release notes](../docs/release-notes.mdx) N/A
- [ ] Ready to be merged
