### PR TITLE
Link inputs and labels when `id` is not provided by the user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22496,6 +22496,11 @@
             "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
             "dev": true
         },
+        "nanoid": {
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
         "@types/react-select": "^3.0.13",
         "@types/styled-system": "^5.1.9",
         "date-fns": "^2.11.1",
+        "nanoid": "^3.1.23",
         "react-select": "^3.1.0",
         "react-tether": "^2.0.7",
         "react-transition-group": "^4.3.0",

--- a/src/components/Datepicker/__snapshots__/DatepickerRangeInput.spec.tsx.snap
+++ b/src/components/Datepicker/__snapshots__/DatepickerRangeInput.spec.tsx.snap
@@ -176,6 +176,7 @@ exports[`DatepickerRangeInput renders the default props 1`] = `
         class="sc-AxirZ c2"
         data-error="false"
         data-testid="start-date-input"
+        id="random"
         type="text"
         value=""
       />
@@ -202,6 +203,7 @@ exports[`DatepickerRangeInput renders the default props 1`] = `
         class="sc-AxirZ c2"
         data-error="false"
         data-testid="end-date-input"
+        id="random"
         tabindex="-1"
         type="text"
         value=""

--- a/src/components/Datepicker/__snapshots__/DatepickerSingleInput.spec.tsx.snap
+++ b/src/components/Datepicker/__snapshots__/DatepickerSingleInput.spec.tsx.snap
@@ -120,6 +120,7 @@ exports[`DatepickerSingleInput renders the default props 1`] = `
       class="sc-AxjAm c1"
       data-error="false"
       data-testid="start-date-input"
+      id="random"
       type="text"
       value=""
     />

--- a/src/components/Input/Input.spec.tsx
+++ b/src/components/Input/Input.spec.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { Input } from './Input';
 
+jest.mock('../../utils/ids');
+
 describe('Input', () => {
     describe('variant "boxed"', () => {
         it('renders', () => {
@@ -72,8 +74,21 @@ describe('Input', () => {
         });
     });
 
-    it('should set the htmlFor attribute for the label', () => {
-        expect(render(<Input id="test-input-id" label="Simple Label" />).container.firstChild).toMatchSnapshot();
+    describe('link input with the label', () => {
+        it('uses `id` prop value if passed', () => {
+            render(<Input id="test-input-id" label="Simple Label" />);
+
+            expect(screen.getByLabelText('Simple Label')).toHaveAttribute('id', 'test-input-id');
+            expect(screen.getByText('Simple Label')).toHaveAttribute('for', 'test-input-id');
+        });
+
+        it('generate id automatically if `id` prop is empty', () => {
+            render(<Input label="Simple Label" />);
+            const generatedId = 'random';
+
+            expect(screen.getByLabelText('Simple Label')).toHaveAttribute('id', generatedId);
+            expect(screen.getByText('Simple Label')).toHaveAttribute('for', generatedId);
+        });
     });
 
     it('allows to be tested using accessible queries', () => {

--- a/src/components/Input/Input.spec.tsx
+++ b/src/components/Input/Input.spec.tsx
@@ -3,8 +3,6 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { Input } from './Input';
 
-jest.mock('../../utils/ids');
-
 describe('Input', () => {
     describe('variant "boxed"', () => {
         it('renders', () => {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,7 +1,6 @@
-import React, { forwardRef, useEffect, useMemo, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { extractClassNameProps, extractWidthProps, extractWrapperMarginProps } from '../../utils/extractProps';
-import { generateId } from '../../utils/ids';
-
+import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 import { BottomLinedInput } from './BottomLinedInput';
 import { BottomLinedInputLabel } from './BottomLinedInputLabel';
 import { BoxedInput } from './BoxedInput';
@@ -15,11 +14,7 @@ const Input = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>((props,
     const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
     const { label, onChange, size, ...rest } = restProps;
-    const id = useMemo(() => {
-        if (props.id) return props.id;
-
-        return label ? generateId() : null;
-    }, [props.id]);
+    const id = useGeneratedId(props.id);
 
     const [hasValue, setHasValue] = useState(rest.value && rest.value.toString().length > 0);
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,7 @@
-import React, { forwardRef, useEffect, useState } from 'react';
+import React, { forwardRef, useEffect, useMemo, useState } from 'react';
 import { extractClassNameProps, extractWidthProps, extractWrapperMarginProps } from '../../utils/extractProps';
+import { generateId } from '../../utils/ids';
+
 import { BottomLinedInput } from './BottomLinedInput';
 import { BottomLinedInputLabel } from './BottomLinedInputLabel';
 import { BoxedInput } from './BoxedInput';
@@ -12,7 +14,8 @@ const Input = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>((props,
     const { marginProps, restProps: withoutMargin } = extractWrapperMarginProps(withoutClassName);
     const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
-    const { label, onChange, size, id, ...rest } = restProps;
+    const { label, onChange, size, ...rest } = restProps;
+    const id = useMemo(() => props.id ?? generateId(), [props.id]);
 
     const [hasValue, setHasValue] = useState(rest.value && rest.value.toString().length > 0);
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -15,7 +15,11 @@ const Input = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>((props,
     const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
     const { label, onChange, size, ...rest } = restProps;
-    const id = useMemo(() => props.id ?? generateId(), [props.id]);
+    const id = useMemo(() => {
+        if (props.id) return props.id;
+
+        return label ? generateId() : null;
+    }, [props.id]);
 
     const [hasValue, setHasValue] = useState(rest.value && rest.value.toString().length > 0);
 

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -116,6 +116,7 @@ exports[`Input variant "bottom-lined" renders 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>
@@ -243,6 +244,7 @@ exports[`Input variant "bottom-lined" renders the error state 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>
@@ -519,6 +521,7 @@ exports[`Input variant "bottom-lined" renders the inverted style 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>
@@ -934,6 +937,7 @@ exports[`Input variant "bottom-lined" renders the small size 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>
@@ -1055,6 +1059,7 @@ exports[`Input variant "boxed" renders 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>
@@ -1182,6 +1187,7 @@ exports[`Input variant "boxed" renders the error state 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>
@@ -1458,6 +1464,7 @@ exports[`Input variant "boxed" renders the inverted style 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>
@@ -1873,6 +1880,7 @@ exports[`Input variant "boxed" renders the small size 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
 </div>

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -1,150 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Input should set the htmlFor attribute for the label 1`] = `
-.c3 {
-  position: absolute;
-  pointer-events: none;
-  background-color: transparent;
-  line-height: 1.5;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: calc(100% - 2rem);
-  -webkit-transition: top 100ms ease-out,left 100ms ease-out, padding 100ms ease-out,font-size 100ms ease-out, color 100ms ease-out,background 100ms ease-out;
-  transition: top 100ms ease-out,left 100ms ease-out, padding 100ms ease-out,font-size 100ms ease-out, color 100ms ease-out,background 100ms ease-out;
-  top: 0.75rem;
-  left: 0.5rem;
-  padding: 0 0.25rem;
-  font-size: 1rem;
-}
-
-.c1 {
-  margin: 0;
-  box-sizing: border-box;
-  background: #FFFFFF;
-  border-radius: 0;
-  color: #001E3E;
-  font-size: 1rem;
-  font-family: "Open Sans",sans-serif;
-  -webkit-transition: box-shadow 100ms,border 100ms;
-  transition: box-shadow 100ms,border 100ms;
-  outline: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  width: 100%;
-  border-radius: 0.25rem;
-  border: 0.0625rem solid #C6CDD4;
-  font-size: 1rem;
-  height: 3rem;
-  padding: 0 0.75rem;
-}
-
-.c1::-webkit-input-placeholder {
-  color: #9CA7B4;
-}
-
-.c1::-moz-placeholder {
-  color: #9CA7B4;
-}
-
-.c1:-ms-input-placeholder {
-  color: #9CA7B4;
-}
-
-.c1::placeholder {
-  color: #9CA7B4;
-}
-
-.c1:active,
-.c1:focus {
-  border-color: #096BDB;
-  box-shadow: inset 0 0 0 0.0625rem #096BDB;
-}
-
-.c1:disabled {
-  color: #C6CDD4;
-  border-color: #C6CDD4;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c1:disabled::-webkit-input-placeholder {
-  color: #C6CDD4;
-}
-
-.c1:disabled::-moz-placeholder {
-  color: #C6CDD4;
-}
-
-.c1:disabled:-ms-input-placeholder {
-  color: #C6CDD4;
-}
-
-.c1:disabled::placeholder {
-  color: #C6CDD4;
-}
-
-.c1:-webkit-autofill,
-.c1:-webkit-autofill:hover,
-.c1:-webkit-autofill:focus,
-.c1:-webkit-autofill:active {
-  -webkit-text-fill-color: #001E3E;
-  -webkit-transition: background-color 99999999ms ease 99999999ms;
-  transition: background-color 99999999ms ease 99999999ms;
-}
-
-.c1 + .c2 {
-  color: #9CA7B4;
-  background: #FFFFFF;
-  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
-}
-
-.c1:disabled + .c2 {
-  color: #C6CDD4;
-}
-
-.c1:-webkit-autofill + .c2,
-.c1:-webkit-autofill:hover + .c2,
-.c1:-webkit-autofill:focus + .c2,
-.c1:-webkit-autofill:active + .c2 {
-  font-weight: 600;
-  top: -0.5rem;
-  font-size: 0.75rem;
-}
-
-.c1:focus:not(:disabled) + .c2 {
-  font-weight: 600;
-  top: -0.5rem;
-  font-size: 0.75rem;
-  color: #096BDB;
-  background: #FFFFFF;
-  background: linear-gradient(0deg,#FFFFFF calc(50% + 0.0625rem),transparent 50%);
-}
-
-.c0 {
-  display: inline-block;
-  position: relative;
-  box-sizing: border-box;
-}
-
-<div
-  class="c0"
->
-  <input
-    class="sc-AxjAm c1"
-    id="test-input-id"
-    type="text"
-  />
-  <label
-    class="sc-AxirZ c2 c3"
-    for="test-input-id"
-  >
-    Simple Label
-  </label>
-</div>
-`;
-
 exports[`Input variant "bottom-lined" renders 1`] = `
 .c1 {
   margin: 0;
@@ -535,11 +390,13 @@ exports[`Input variant "bottom-lined" renders the error state with label and pla
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     placeholder="FREE NOW"
     type="text"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -800,10 +657,12 @@ exports[`Input variant "bottom-lined" renders the label 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -946,11 +805,13 @@ exports[`Input variant "bottom-lined" renders the label and the placeholder 1`] 
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     placeholder="FREE NOW"
     type="text"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -1468,11 +1329,13 @@ exports[`Input variant "boxed" renders the error state with label and placeholde
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     placeholder="FREE NOW"
     type="text"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -1733,10 +1596,12 @@ exports[`Input variant "boxed" renders the label 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     type="text"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -1879,11 +1744,13 @@ exports[`Input variant "boxed" renders the label and the placeholder 1`] = `
 >
   <input
     class="sc-AxjAm c1"
+    id="random"
     placeholder="FREE NOW"
     type="text"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system';
 import { theme } from '../../essentials/theme';
+import { generateId } from '../../utils/ids';
 import { ChevronDownIcon } from '../../icons/basic';
 import { extractClassNameProps, extractWidthProps, extractWrapperMarginProps } from '../../utils/extractProps';
 import { BaseSelectProps, SelectInput } from './SelectInput';
@@ -39,15 +40,20 @@ const Select: React.FC<SelectProps> = props => {
     const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
     const { label, ...rest } = restProps;
+    const id = useMemo(() => {
+        if (props.id) return props.id;
+
+        return label ? generateId() : null;
+    }, [props.id]);
 
     return (
         <SelectWrapper {...classNameProps} {...marginProps} {...widthProps}>
-            <SelectInput {...rest} />
+            <SelectInput {...rest} id={id} />
             <IconNode className="svg-icon">
                 <ChevronDownIcon />
             </IconNode>
             {label && (
-                <SelectLabel inverted={props.inverted} htmlFor={props.id}>
+                <SelectLabel inverted={props.inverted} htmlFor={id}>
                     {label}
                 </SelectLabel>
             )}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system';
 import { theme } from '../../essentials/theme';
-import { generateId } from '../../utils/ids';
+import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 import { ChevronDownIcon } from '../../icons/basic';
 import { extractClassNameProps, extractWidthProps, extractWrapperMarginProps } from '../../utils/extractProps';
 import { BaseSelectProps, SelectInput } from './SelectInput';
@@ -40,11 +40,7 @@ const Select: React.FC<SelectProps> = props => {
     const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
     const { label, ...rest } = restProps;
-    const id = useMemo(() => {
-        if (props.id) return props.id;
-
-        return label ? generateId() : null;
-    }, [props.id]);
+    const id = useGeneratedId(props.id);
 
     return (
         <SelectWrapper {...classNameProps} {...marginProps} {...widthProps}>

--- a/src/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -375,6 +375,7 @@ exports[`Select variant "bottom-lined" renders the disabled styles 1`] = `
   <select
     class="c1"
     disabled=""
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -394,6 +395,7 @@ exports[`Select variant "bottom-lined" renders the disabled styles 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     disabled
   </label>
@@ -521,6 +523,7 @@ exports[`Select variant "bottom-lined" renders the error styles 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -540,6 +543,7 @@ exports[`Select variant "bottom-lined" renders the error styles 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     error
   </label>
@@ -673,6 +677,7 @@ exports[`Select variant "bottom-lined" renders the inverted disabled styles 1`] 
   <select
     class="c1"
     disabled=""
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -692,6 +697,7 @@ exports[`Select variant "bottom-lined" renders the inverted disabled styles 1`] 
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     inverted disabled
   </label>
@@ -813,6 +819,7 @@ exports[`Select variant "bottom-lined" renders the inverted styles 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -832,6 +839,7 @@ exports[`Select variant "bottom-lined" renders the inverted styles 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     inverted
   </label>
@@ -953,6 +961,7 @@ exports[`Select variant "bottom-lined" renders with a label 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -972,6 +981,7 @@ exports[`Select variant "bottom-lined" renders with a label 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     label
   </label>
@@ -1353,6 +1363,7 @@ exports[`Select variant "boxed" renders the disabled styles 1`] = `
   <select
     class="c1"
     disabled=""
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -1372,6 +1383,7 @@ exports[`Select variant "boxed" renders the disabled styles 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     disabled
   </label>
@@ -1493,6 +1505,7 @@ exports[`Select variant "boxed" renders the error styles 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -1512,6 +1525,7 @@ exports[`Select variant "boxed" renders the error styles 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     error
   </label>
@@ -1639,6 +1653,7 @@ exports[`Select variant "boxed" renders the inverted disabled styles 1`] = `
   <select
     class="c1"
     disabled=""
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -1658,6 +1673,7 @@ exports[`Select variant "boxed" renders the inverted disabled styles 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     inverted disabled
   </label>
@@ -1773,6 +1789,7 @@ exports[`Select variant "boxed" renders the inverted styles 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -1792,6 +1809,7 @@ exports[`Select variant "boxed" renders the inverted styles 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     inverted
   </label>
@@ -1907,6 +1925,7 @@ exports[`Select variant "boxed" renders with a label 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -1926,6 +1945,7 @@ exports[`Select variant "boxed" renders with a label 1`] = `
   </div>
   <label
     class="c3 c4"
+    for="random"
   >
     label
   </label>

--- a/src/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -98,6 +98,7 @@ exports[`Select renders with default props 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -216,6 +217,7 @@ exports[`Select variant "bottom-lined" renders passed options 1`] = `
 >
   <select
     class="c1"
+    id="random"
   >
     <option
       value="1"
@@ -1092,6 +1094,7 @@ exports[`Select variant "bottom-lined" renders with default props 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"
@@ -1210,6 +1213,7 @@ exports[`Select variant "boxed" renders passed options 1`] = `
 >
   <select
     class="c1"
+    id="random"
   >
     <option
       value="1"
@@ -2050,6 +2054,7 @@ exports[`Select variant "boxed" renders with default props 1`] = `
 >
   <select
     class="c1"
+    id="random"
   />
   <div
     class="c2 svg-icon"

--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -2,8 +2,6 @@ import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { Textarea } from './Textarea';
 
-jest.mock('../../utils/ids');
-
 describe('Textarea', () => {
     it('renders', () => {
         expect(render(<Textarea />).container.firstChild).toMatchSnapshot();

--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -1,6 +1,8 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { Textarea } from './Textarea';
+
+jest.mock('../../utils/ids');
 
 describe('Textarea', () => {
     it('renders', () => {
@@ -37,5 +39,22 @@ describe('Textarea', () => {
         expect(
             render(<Textarea label="Name" placeholder="FREE NOW" disabled />).container.firstChild
         ).toMatchSnapshot();
+    });
+
+    describe('link textarea with the label', () => {
+        it('uses `id` prop value if passed', () => {
+            render(<Textarea id="test-input-id" label="Simple Label" />);
+
+            expect(screen.getByLabelText('Simple Label')).toHaveAttribute('id', 'test-input-id');
+            expect(screen.getByText('Simple Label')).toHaveAttribute('for', 'test-input-id');
+        });
+
+        it('generate id automatically if `id` prop is empty', () => {
+            render(<Textarea label="Simple Label" />);
+            const generatedId = 'random';
+
+            expect(screen.getByLabelText('Simple Label')).toHaveAttribute('id', generatedId);
+            expect(screen.getByText('Simple Label')).toHaveAttribute('for', generatedId);
+        });
     });
 });

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,15 +1,15 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import styled, { CSSProperties } from 'styled-components';
 
 import { compose, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system';
 import { theme } from '../../essentials/theme';
-import { generateId } from '../../utils/ids';
 import {
     extractClassNameProps,
     extractHeightProps,
     extractWidthProps,
     extractWrapperMarginProps
 } from '../../utils/extractProps';
+import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 
 import { InternalInputComponentProps } from '../Input/BaseInput';
 import { BoxedInput } from '../Input/BoxedInput';
@@ -54,11 +54,7 @@ const Textarea: FC<InputWrapperProps & TextAreaProps> = props => {
     const { heightProps, restProps } = extractHeightProps(withoutWidth);
 
     const { label, onChange, resize, ...rest } = restProps;
-    const id = useMemo(() => {
-        if (props.id) return props.id;
-
-        return label ? generateId() : null;
-    }, [props.id]);
+    const id = useGeneratedId(props.id);
 
     const [hasValue, setHasValue] = useState(rest.value && rest.value.toString().length > 0);
 

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,16 +1,17 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import styled, { CSSProperties } from 'styled-components';
 
 import { compose, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system';
 import { theme } from '../../essentials/theme';
+import { generateId } from '../../utils/ids';
 import {
     extractClassNameProps,
     extractHeightProps,
     extractWidthProps,
     extractWrapperMarginProps
 } from '../../utils/extractProps';
-import { InternalInputComponentProps } from '../Input/BaseInput';
 
+import { InternalInputComponentProps } from '../Input/BaseInput';
 import { BoxedInput } from '../Input/BoxedInput';
 import { BoxedInputLabel } from '../Input/BoxedInputLabel';
 import { InputProps } from '../Input/InputProps';
@@ -52,7 +53,12 @@ const Textarea: FC<InputWrapperProps & TextAreaProps> = props => {
     const { widthProps, restProps: withoutWidth } = extractWidthProps(withoutMargin);
     const { heightProps, restProps } = extractHeightProps(withoutWidth);
 
-    const { label, onChange, id, resize, ...rest } = restProps;
+    const { label, onChange, resize, ...rest } = restProps;
+    const id = useMemo(() => {
+        if (props.id) return props.id;
+
+        return label ? generateId() : null;
+    }, [props.id]);
 
     const [hasValue, setHasValue] = useState(rest.value && rest.value.toString().length > 0);
 

--- a/src/components/Textarea/__snapshots__/Textarea.spec.tsx.snap
+++ b/src/components/Textarea/__snapshots__/Textarea.spec.tsx.snap
@@ -269,10 +269,12 @@ exports[`Textarea renders the disabled state with label and placeholder 1`] = `
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
     disabled=""
+    id="random"
     placeholder="FREE NOW"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -559,10 +561,12 @@ exports[`Textarea renders the error state with label and placeholder 1`] = `
 >
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
+    id="random"
     placeholder="FREE NOW"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -834,9 +838,11 @@ exports[`Textarea renders the label 1`] = `
 >
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
+    id="random"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -985,10 +991,12 @@ exports[`Textarea renders the label and the placeholder 1`] = `
 >
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
+    id="random"
     placeholder="FREE NOW"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>
@@ -1141,10 +1149,12 @@ exports[`Textarea renders with custom height and width 1`] = `
 >
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
+    id="random"
     placeholder="FREE NOW"
   />
   <label
     class="sc-AxirZ c2 c3"
+    for="random"
   >
     Name
   </label>

--- a/src/components/Textarea/__snapshots__/Textarea.spec.tsx.snap
+++ b/src/components/Textarea/__snapshots__/Textarea.spec.tsx.snap
@@ -122,6 +122,7 @@ exports[`Textarea renders 1`] = `
 >
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
+    id="random"
   />
 </div>
 `;
@@ -409,6 +410,7 @@ exports[`Textarea renders the error state 1`] = `
 >
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
+    id="random"
   />
 </div>
 `;
@@ -695,6 +697,7 @@ exports[`Textarea renders the inverted style 1`] = `
 >
   <textarea
     class="sc-AxjAm sc-AxhCb c1"
+    id="random"
   />
 </div>
 `;

--- a/src/utils/__mocks__/ids.ts
+++ b/src/utils/__mocks__/ids.ts
@@ -1,0 +1,3 @@
+export const generateId = (): string => {
+    return 'random';
+};

--- a/src/utils/hooks/useGeneratedId.ts
+++ b/src/utils/hooks/useGeneratedId.ts
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+import { generateId } from '../ids';
+
+const useGeneratedId = (id: string | undefined | null) => {
+    return useMemo(() => id || generateId(), [id]);
+};
+
+export { useGeneratedId };

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,0 +1,5 @@
+import { nanoid } from 'nanoid';
+
+export const generateId = (): string => {
+    return `wave-${nanoid(6)}`;
+};

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -13,6 +13,9 @@ declare global {
     }
 }
 
+// mock the source of randomness in all the tests
+jest.mock('./ids');
+
 expect.extend({
     toMatchHtmlTag(wrapper: RenderResult, expectedTag: string): CustomMatcherResult {
         const { firstChild } = wrapper.container;


### PR DESCRIPTION
**What:**
Fixes critical accessibility issue for `Input`, `Textarea` and `Select`. Always links input to the corresponding labels
​
**Why:**
It is recommended to have inputs and corresponding labels linked. The input must provide an `id` and label references this id in the `for` attribute.

In the mentioned above components we create this relation only when the developer passed `id` property to the component. If not, the component seriously violates [the accessibility guidelines about the labels](https://dequeuniversity.com/rules/axe/4.2/label)

**How:**

New dependency [nanoid](https://github.com/ai/nanoid) which is 108 bytes minified and gzipped.

1. If the user provides an `id` prop we use it as an id
2. If not, but there is no label, do nothing
3. If not, and the label exists, generate a random id in the form `wave-{6 random characters)`


**Media:**

https://www.loom.com/share/ddaf8f367e4d4b7b9eb5afc830df80ca

**Checklist:**

- [x] Ready to be merged