### PR TITLE
docs(a11y): add a section to help over a11y

### DIFF
--- a/docs/accessibility.mdx
+++ b/docs/accessibility.mdx
@@ -1,0 +1,36 @@
+---
+name: Accessibility
+route: /a11y
+---
+
+import { TitleCard } from './components/TitleCard';
+
+<TitleCard title="Accessibility (a11y)">
+    Accessible design not only helps users with disabilities; it provides better user experiences for everyone.
+</TitleCard>
+
+## Overview
+
+Accessible design not only helps users with disabilities; it provides better user experiences for everyone. Our goal is to provide a consistent user experience for all users, whether they’re navigating with a mouse/touchscreen, keyboard, or screen reader.
+
+An accessible product should:
+
+- Give all users the same quality of experience
+- Adapt to users and situations
+
+Individually accessible elements and components are part of building accessible products, but the accessibility efforts need for manual testing. When designing new UIs, rely as much as possible on Wave existing components and follow accessible patterns. If you're creating a new component or pattern (one that doesn't exist in Wave), keep in mind accessibility practices before your implementation.
+
+## Mission
+
+The Wave Design System team wants as many people as possible to be able to use Wave powered products. For example, that means you should be able to:
+
+- **zoom** in up to 300% without the text spilling off the screen
+- navigate most of the website using just a **keyboard**
+- listen to most of the website using a **screen reader**
+
+## Aid development process
+
+- Use the [a11y project checklist](https://www.a11yproject.com/checklist/) and aim for at least A level compliance
+- Use [axe dev tools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) for accessibility testing. Check more at [deque Axe](https://www.deque.com/axe/devtools/)
+- Use [Lighthouse Chrome extension](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk?hl=en) for accessibility score. Check more at [Web.dev a11y](https://web.dev/accessibility-scoring/)
+- Use [accessible queries](https://testing-library.com/docs/queries/about#priority) when writing tests. This assume you are using [testing-library](https://testing-library.com/)

--- a/docs/accessibility.mdx
+++ b/docs/accessibility.mdx
@@ -11,7 +11,7 @@ import { TitleCard } from './components/TitleCard';
 
 ## Overview
 
-Accessible design not only helps users with disabilities; it provides better user experiences for everyone. Our goal is to provide a consistent user experience for all users, whether they’re navigating with a mouse/touchscreen, keyboard, or screen reader.
+Our goal is to provide a consistent user experience for all users, whether they’re navigating with a mouse/touchscreen, keyboard, or screen reader.
 
 An accessible product should:
 

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
     title: `Wave`,
-    menu: ['Get Started', 'Changelog', 'Contributing', 'Essentials', 'Components'],
+    menu: ['Get Started', 'Changelog', 'Accessibility', 'Contributing', 'Essentials', 'Components'],
     ignore: ['CONTRIBUTING.md', 'README.md', 'SECURITY.md', 'MAINTAINERS.md', 'fixtures/**/*.md', '.idea/**/*'],
     propsParser: false,
     typescript: true,


### PR DESCRIPTION
**What:**
Add a page for "Accessibility"
​
**Why:**
The idea is to provide guidance on how to include a11y in the implementation phase and also to make transparent our expectations on this subject.
​
**Media:**
[New page for Accessibility overview](https://user-images.githubusercontent.com/1425162/119520930-00fade00-bd7b-11eb-8f5e-e2ff69c69039.png)

**Checklist:**
- [x] Ready to be merged

**Notes:**
I open the PR with the idea to bring the conversation async taking some assumptions from past decisions and conversations.

**Useful links:**
I found it useful to take a look at other people work such as:
- https://design-system.service.gov.uk/
- https://speakerdeck.com/bennoloewenberg/accessibility-in-design-systems-english
- https://www.carbondesignsystem.com/guidelines/accessibility/overview

_In the future we can include a set of common practices, similar to https://www.lightningdesignsystem.com/accessibility/guidelines/web-design/_