### PR TITLE
docs(templates): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ about: Bugs, missing documentation, or unexpected behavior 🤔.
 var your => (code) => here;
 ```
 
-### Problem description
+### What was expected to happen?
 
 <!-- Please describe why the current behavior is a problem -->
 
@@ -28,11 +28,4 @@ var your => (code) => here;
 <!--
 If you can, try to reproduce the issue in a Codesandbox. You can fork the one
 here: https://codesandbox.io/s/wave-playground-w7cf3 (make sure to use latest Wave version)
--->
-
-### Suggested solution
-
-<!--
-It's ok if you don't have a suggested solution, but it really helps if you could
-do a little digging to come up with some suggestion of how to improve things.
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: 🐛 Bug Report
+about: Bugs, missing documentation, or unexpected behavior 🤔.
+---
+
+<!--
+
+* Please fill out this template with all the relevant information so we can
+  understand what's going on and fix the issue. We appreciate bugs filed and PRs
+  submitted!
+
+-->
+
+- `@freenow/wave` version:
+
+### Relevant code
+
+```js
+var your => (code) => here;
+```
+
+### What you did
+
+<!-- What you were doing -->
+
+### What happened
+
+<!-- Please provide the full error message/screenshots/anything -->
+
+### Reproduction
+
+<!--
+If you can, try to reproduce the issue in a Codesandbox. You can fork the one
+here: https://codesandbox.io/s/wave-playground-w7cf3 (make sure to use latest Wave version)
+-->
+
+### Problem description
+
+<!-- Please describe why the current behavior is a problem -->
+
+### Suggested solution
+
+<!--
+It's ok if you don't have a suggested solution, but it really helps if you could
+do a little digging to come up with some suggestion of how to improve things.
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ about: Bugs, missing documentation, or unexpected behavior 🤔.
 
 -->
 
-- `@freenow/wave` version:
+-   `@freenow/wave` version:
 
 ### Relevant code
 
@@ -19,13 +19,9 @@ about: Bugs, missing documentation, or unexpected behavior 🤔.
 var your => (code) => here;
 ```
 
-### What you did
+### Problem description
 
-<!-- What you were doing -->
-
-### What happened
-
-<!-- Please provide the full error message/screenshots/anything -->
+<!-- Please describe why the current behavior is a problem -->
 
 ### Reproduction
 
@@ -33,10 +29,6 @@ var your => (code) => here;
 If you can, try to reproduce the issue in a Codesandbox. You can fork the one
 here: https://codesandbox.io/s/wave-playground-w7cf3 (make sure to use latest Wave version)
 -->
-
-### Problem description
-
-<!-- Please describe why the current behavior is a problem -->
 
 ### Suggested solution
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,13 @@
+---
+name: ❓ Support Question
+about: 🛑 If you have a question 💬, please file it here. It will help to create a knowledge base
+---
+
+### Support questions
+
+<!--
+
+* Please make sure you have read the documentation in our homepage https://wave.free-now.com/
+  if you have done it but yet have the question then go a head and file a question issue
+
+-->

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -1,0 +1,40 @@
+---
+name: 💡 Feature Request
+about: I have a suggestion (and might want to implement myself 🙂)!
+---
+
+<!--
+
+Vote on feature requests by adding a 👍. This helps maintainers prioritize what
+to work on.
+
+* Please fill out this template with all the relevant information so we can
+  understand what's going on and fix the issue. We appreciate bugs filed and PRs
+  submitted!
+
+-->
+
+### Describe the feature you'd like
+
+<!--
+A clear and concise description of what you want to happen. Add any considered
+drawbacks.
+-->
+
+### Suggested implementation
+
+<!-- Helpful but optional 😀 -->
+
+### Describe alternatives you've considered
+
+<!--
+A clear and concise description of any alternative solutions or features you've
+considered.
+-->
+
+### Teachability, Documentation, Adoption, Migration Strategy
+
+<!--
+If you can, explain how users will be able to use this and possibly write out a
+version of the docs.
+-->

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -31,10 +31,3 @@ drawbacks.
 A clear and concise description of any alternative solutions or features you've
 considered.
 -->
-
-### Teachability, Documentation, Adoption, Migration Strategy
-
-<!--
-If you can, explain how users will be able to use this and possibly write out a
-version of the docs.
--->

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -5,8 +5,7 @@ about: I have a suggestion (and might want to implement myself 🙂)!
 
 <!--
 
-Vote on feature requests by adding a 👍. This helps maintainers prioritize what
-to work on.
+Vote on feature requests by adding a 👍. This helps the community to prioritise what to start with
 
 * Please fill out this template with all the relevant information so we can
   understand what's going on and fix the issue. We appreciate bugs filed and PRs
@@ -20,10 +19,6 @@ to work on.
 A clear and concise description of what you want to happen. Add any considered
 drawbacks.
 -->
-
-### Suggested implementation
-
-<!-- Helpful but optional 😀 -->
 
 ### Describe alternatives you've considered
 


### PR DESCRIPTION
**What:**
Add templates to structure the issues submitted
​
**Why:**
There are some conversations and feedback process that can be optimized once we have a specific structure
​
**How:**
_I follow similar approaches as `react-testing-library`_
​
**Media:**
The idea is to achieve something like the image below:

![image](https://user-images.githubusercontent.com/1425162/119649696-3529d980-be23-11eb-983b-f71888a14e30.png)


**Checklist:**
- [x] Ready to be merged