### PR TITLE
Adds disabled checkbox text color

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -49,7 +49,11 @@ const Checkbox: FC<CheckboxProps> = props => {
     let dynamicLabel: ReactNode = label;
 
     if (typeof label === 'string') {
-        dynamicLabel = <Text fontSize={size}>{label}</Text>;
+        dynamicLabel = (
+            <Text disabled={disabled} fontSize={size}>
+                {label}
+            </Text>
+        );
     }
 
     return (

--- a/src/components/Text/Text.spec.tsx
+++ b/src/components/Text/Text.spec.tsx
@@ -16,10 +16,31 @@ describe('Text', () => {
         expect(render(<Text>Content</Text>).getByText('Content')).toBeInTheDocument();
     });
 
-    it('has a dim color if weak property is set', () => {
-        expect(render(<Text weak />).container.firstChild).toHaveStyle(`
-            color: ${Colors.AUTHENTIC_BLUE_550};
-        `);
+    describe('if the weak property is set', () => {
+        it('has a dim color', () => {
+            expect(render(<Text weak />).container.firstChild).toHaveStyle(`
+                color: ${Colors.AUTHENTIC_BLUE_550};
+            `);
+        });
+
+        it('has a dimmer color if inverted', () => {
+            expect(render(<Text weak inverted />).container.firstChild).toHaveStyle(`
+                color: ${Colors.AUTHENTIC_BLUE_350};
+            `);
+        });
+    });
+
+    describe('if the disabled property is set', () => {
+        it('has the disabled color', () => {
+            expect(render(<Text disabled />).container.firstChild).toHaveStyle(`
+                color: ${Colors.AUTHENTIC_BLUE_350};
+            `);
+        });
+        it('has a stronger disabled color if inverted', () => {
+            expect(render(<Text disabled inverted />).container.firstChild).toHaveStyle(`
+                color: ${Colors.AUTHENTIC_BLUE_550};
+            `);
+        });
     });
 
     it('has a bright color if inverted property is set', () => {

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -35,11 +35,19 @@ interface TextProps
      * Adjust color to indicate secondary information
      */
     weak?: boolean;
+    /**
+     * Adjust color to display a disabled text element
+     */
+    disabled?: boolean;
 }
 
-function determineTextColor({ weak, inverted }: TextProps) {
-    if (weak || (weak && inverted)) {
-        return Colors.AUTHENTIC_BLUE_550;
+function determineTextColor({ weak, inverted, disabled }: TextProps) {
+    if (disabled) {
+        return inverted ? Colors.AUTHENTIC_BLUE_550 : Colors.AUTHENTIC_BLUE_350;
+    }
+
+    if (weak) {
+        return inverted ? Colors.AUTHENTIC_BLUE_350 : Colors.AUTHENTIC_BLUE_550;
     }
 
     if (inverted) {

--- a/src/components/Text/docs/Text.mdx
+++ b/src/components/Text/docs/Text.mdx
@@ -59,3 +59,13 @@ The Text component is a wrapper component that will apply typography styles to t
     <Text as="p" weak fontSize={1} inverted>paragraph weak inverted medium</Text>
     <Text as="p" weak fontSize={0} inverted>paragraph weak inverted small</Text>
 </ItemWrapper>
+<ItemWrapper>
+    <Text as="p" disabled>paragraph disabled large</Text>
+    <Text as="p" disabled fontSize={1}>paragraph disabled medium</Text>
+    <Text as="p" disabled fontSize={0}>paragraph disabled small</Text>
+</ItemWrapper>
+<ItemWrapper inverted>
+    <Text as="p" disabled inverted>paragraph disabled inverted large</Text>
+    <Text as="p" disabled fontSize={1} inverted>paragraph disabled inverted medium</Text>
+    <Text as="p" disabled fontSize={0} inverted>paragraph disabled inverted small</Text>
+</ItemWrapper>


### PR DESCRIPTION
**What:**
This PR fixes the color of the text of the `disabled` state for the `Checbox` component.
​
**Why:**
This is in regard to [SUP-11111](https://jira.intapps.it/browse/SUP-11111)
​
**How:**
* Pass the `disabled` property to the `Text` component inside `Checkbox`
​
**Media:**
![Design](https://user-images.githubusercontent.com/5729666/119816090-95d11900-beec-11eb-9825-90cfc850dd21.png)
<img width="288" alt="Screenshot of documentation" src="https://user-images.githubusercontent.com/5729666/119816145-a6818f00-beec-11eb-8f2d-bdfb481e476c.png">

> Note: This PR should ideally be merged only after [the preceding one](https://github.com/freenowtech/wave/pull/96) is merged, so that we can isolate changes in the merge commit with the ticket (currently, changes for [SUP-11112](https://jira.intapps.it/browse/SUP-11112) are included here as well)
