### PR TITLE
Fixes Password component do not react on `width` property

### DIFF
--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -11,11 +11,16 @@ import { Colors } from '../../essentials/Colors/Colors';
 import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 import { ToggleButton } from './ToggleButton';
 import { TOGGLE_MODE_BUTTON_WIDTH } from './constants';
+import { extractWidthProps, extractWrapperMarginProps } from '../../utils/extractProps';
+import { compose, MarginProps, margin, width, WidthProps } from 'styled-system';
 
-const PasswordWrapper = styled.div`
+type WrapperProps = MarginProps & WidthProps;
+const PasswordWrapper = styled.div<WrapperProps>`
     display: inline-block;
     position: relative;
     box-sizing: border-box;
+
+    ${compose(margin, width)}
 
     input {
         /* avoid text under the toggle mode button */
@@ -54,11 +59,14 @@ const Password = forwardRef<HTMLDivElement, PasswordProps>(
         };
         const { color, hover } = iconColors[inverted ? 'inverted' : 'regular'];
         const inputId = useGeneratedId(id);
+        const { marginProps, restProps: withoutMargin } = extractWrapperMarginProps(rest);
+        const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
         return (
-            <PasswordWrapper>
+            <PasswordWrapper {...widthProps} {...marginProps}>
                 <Input
-                    {...rest}
+                    {...restProps}
+                    width="100%"
                     id={inputId}
                     size={size}
                     variant={variant}

--- a/src/components/Password/docs/Password.mdx
+++ b/src/components/Password/docs/Password.mdx
@@ -8,6 +8,7 @@ import { Playground } from 'docz';
 import { Combination } from '../../../docs/Combination';
 import { ControlledPassword } from './ControlledPassword';
 import { PasswordPropsTable } from './PasswordPropsTable';
+import {Box} from "../../Box/Box"
 import { Video } from './Video';
 
 # Password
@@ -49,7 +50,15 @@ This will allow password managers to generate a password for the user automatica
 
 
 <Playground>
-    <ControlledPassword label="Password"/>
+
+    <div><ControlledPassword label="Password"/></div>
+    <div><ControlledPassword label="Password" width="100%" my={2}/></div>
+
+    <Box display="flex" flexDirection="column">
+        <ControlledPassword label="Password"/>
+        <ControlledPassword label="Password" width="100%" my={2}/>
+    </Box>
+
 </Playground>
 
 


### PR DESCRIPTION
## What
Fixes the issue when the `Password` component does not take the full width of the container, when `width="100%"` is set.
​
## Why
Closes #100 

## How

The password component has two wrappers: 
* the outer wrapper containing the input and the show password button
* the inner wrapper with the input element with the label.

We passed all the props, including width, to the inner one. That caused issues when we want to set the width of the component. The width value was passed to the inner wrapper → the width of the input is changing, but not the width of the whole component.

The solution was to set the inner wrapper to fill the whole outer wrapper and pass width and margin props to the outer wrapper. In that case, we have two wrappers controlled by the outer one.
​
## Media

Demo: https://www.loom.com/share/9c025f876b4d4de996bf1699e1bab57e

### Before:
<img width="813" alt="image" src="https://user-images.githubusercontent.com/1469636/120490459-b69be180-c3b8-11eb-9b4d-8ff5d3aef5b0.png">

### After:
<img width="894" alt="image" src="https://user-images.githubusercontent.com/1469636/120490540-c4e9fd80-c3b8-11eb-8e96-5e104439075b.png">


## Checklist

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
