### PR TITLE
Use correct version of wave in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@freenow/wave",
-    "version": "1.25.1",
+    "version": "1.1.0",
     "description": "React components of the Wave design system for your Front-End project",
     "main": "lib/cjs/index.js",
     "typings": "lib/types/index.d.ts",


### PR DESCRIPTION
**What:**
Fixes the version of the library in package.json
​
**Why:**
I don't know why but the version in package.json is out of sync. It probably happened when we moved it from the internal repo.

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
