### PR TITLE
Separates headline styles from heading level

### DIFF
--- a/src/components/Headline/Headline.spec.tsx
+++ b/src/components/Headline/Headline.spec.tsx
@@ -13,16 +13,16 @@ describe('Headline', () => {
         expect(render(<Headline as="h5" />)).toMatchHtmlTag('h5');
     });
 
-    it('uses size from the "size" prop', () => {
+    it('"size" prop has precedence over "as" prop', () => {
         render(
-            <Headline as="h2" size="m">
+            <Headline as="h2" size="xs">
                 Headline
             </Headline>
         );
         const headline = screen.getByRole('heading', { level: 2 });
 
         expect(headline).toHaveStyle(`
-          font-size: ${theme.fontSizes[2]}
+          font-size: ${theme.fontSizes[0]}
         `);
     });
 

--- a/src/components/Headline/Headline.spec.tsx
+++ b/src/components/Headline/Headline.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { Colors } from '../../essentials';
 import { theme } from '../../essentials/theme';
@@ -13,6 +13,19 @@ describe('Headline', () => {
         expect(render(<Headline as="h5" />)).toMatchHtmlTag('h5');
     });
 
+    it('uses size from the "size" prop', () => {
+        render(
+            <Headline as="h2" size="medium">
+                Headline
+            </Headline>
+        );
+        const headline = screen.getByRole('heading', { level: 2 });
+
+        expect(headline).toHaveStyle(`
+          font-size: ${theme.fontSizes[4]}
+        `);
+    });
+
     it('renders the children', () => {
         expect(render(<Headline>Content</Headline>).getByText('Content')).toBeInTheDocument();
     });
@@ -23,7 +36,7 @@ describe('Headline', () => {
         `);
     });
 
-    describe('renders different headline sizes', () => {
+    describe('renders different default headline sizes', () => {
         const testCases = [
             ['h1', theme.fontSizes[7]],
             ['h2', theme.fontSizes[5]],

--- a/src/components/Headline/Headline.spec.tsx
+++ b/src/components/Headline/Headline.spec.tsx
@@ -38,39 +38,41 @@ describe('Headline', () => {
 
     describe('renders different default headline sizes', () => {
         const testCases = [
-            ['h1', theme.fontSizes[7]],
-            ['h2', theme.fontSizes[5]],
-            ['h3', theme.fontSizes[4]],
-            ['h4', theme.fontSizes[2]],
-            ['h5', theme.fontSizes[1]],
-            ['h6', theme.fontSizes[0]]
-        ];
+            ['h1', { fontSize: theme.fontSizes[7], lineHeight: '3.75rem' }],
+            ['h2', { fontSize: theme.fontSizes[5], lineHeight: '2.5rem' }],
+            ['h3', { fontSize: theme.fontSizes[4], lineHeight: '2rem' }],
+            ['h4', { fontSize: theme.fontSizes[2], lineHeight: '1.375rem' }],
+            ['h5', { fontSize: theme.fontSizes[1], lineHeight: '1.25rem' }],
+            ['h6', { fontSize: theme.fontSizes[0], lineHeight: '1.125rem' }]
+        ] as const;
 
         test.each(testCases)(
-            'in size %s with correct font size',
-            (headline: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', expected) => {
+            '"%s" with correct styles',
+            (headline: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', expectedStyles) => {
                 expect(render(<Headline as={headline} />).container.firstChild).toHaveStyle(`
-                font-size: ${expected};
+                font-size: ${expectedStyles.fontSize};
+                line-height: ${expectedStyles.lineHeight};
             `);
             }
         );
     });
 
-    describe('renders headline with provided sizes', () => {
+    describe('renders headline styles with provided sizes', () => {
         const testCases = [
-            ['xxl', theme.fontSizes[7]],
-            ['xl', theme.fontSizes[5]],
-            ['l', theme.fontSizes[4]],
-            ['m', theme.fontSizes[2]],
-            ['s', theme.fontSizes[1]],
-            ['xs', theme.fontSizes[0]]
+            ['xxl', { fontSize: theme.fontSizes[7], lineHeight: '3.75rem' }],
+            ['xl', { fontSize: theme.fontSizes[5], lineHeight: '2.5rem' }],
+            ['l', { fontSize: theme.fontSizes[4], lineHeight: '2rem' }],
+            ['m', { fontSize: theme.fontSizes[2], lineHeight: '1.375rem' }],
+            ['s', { fontSize: theme.fontSizes[1], lineHeight: '1.25rem' }],
+            ['xs', { fontSize: theme.fontSizes[0], lineHeight: '1.125rem' }]
         ] as const;
 
-        test.each(testCases)('size %s uses correct font-size', (sizeName, expectedFontSize) => {
+        test.each(testCases)('size "%s" with correct styles', (sizeName, expectedStyles) => {
             render(<Headline size={sizeName}>Headline</Headline>);
 
             expect(screen.getByRole('heading', { level: 1 })).toHaveStyle(`
-            font-size: ${expectedFontSize};
+            font-size: ${expectedStyles.fontSize};
+            line-height: ${expectedStyles.lineHeight};
         `);
         });
     });

--- a/src/components/Headline/Headline.spec.tsx
+++ b/src/components/Headline/Headline.spec.tsx
@@ -15,14 +15,14 @@ describe('Headline', () => {
 
     it('uses size from the "size" prop', () => {
         render(
-            <Headline as="h2" size="medium">
+            <Headline as="h2" size="m">
                 Headline
             </Headline>
         );
         const headline = screen.getByRole('heading', { level: 2 });
 
         expect(headline).toHaveStyle(`
-          font-size: ${theme.fontSizes[4]}
+          font-size: ${theme.fontSizes[2]}
         `);
     });
 
@@ -54,5 +54,24 @@ describe('Headline', () => {
             `);
             }
         );
+    });
+
+    describe('renders headline with provided sizes', () => {
+        const testCases = [
+            ['xxl', theme.fontSizes[7]],
+            ['xl', theme.fontSizes[5]],
+            ['l', theme.fontSizes[4]],
+            ['m', theme.fontSizes[2]],
+            ['s', theme.fontSizes[1]],
+            ['xs', theme.fontSizes[0]]
+        ] as const;
+
+        test.each(testCases)('size %s uses correct font-size', (sizeName, expectedFontSize) => {
+            render(<Headline size={sizeName}>Headline</Headline>);
+
+            expect(screen.getByRole('heading', { level: 1 })).toHaveStyle(`
+            font-size: ${expectedFontSize};
+        `);
+        });
     });
 });

--- a/src/components/Headline/Headline.tsx
+++ b/src/components/Headline/Headline.tsx
@@ -17,6 +17,7 @@ interface HeadlineProps
      * Set the html tag for the headline including the appropriate styles
      */
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    size?: 'medium';
 }
 
 function determineFontSize(props: HeadlineProps) {
@@ -24,6 +25,14 @@ function determineFontSize(props: HeadlineProps) {
         font-size: ${get('fontSizes.7')};
         line-height: 3.75rem;
     `;
+
+    switch (props.size) {
+        case 'medium':
+            return css`
+                font-size: ${get('fontSizes.4')};
+                line-height: 2rem;
+            `;
+    }
 
     switch (props.as) {
         case 'h1':

--- a/src/components/Headline/Headline.tsx
+++ b/src/components/Headline/Headline.tsx
@@ -23,13 +23,23 @@ interface HeadlineProps
     size?: 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs';
 }
 
+const DEFAULT_HEADLINE_SIZE = {
+    h1: 'xxl',
+    h2: 'xl',
+    h3: 'l',
+    h4: 'm',
+    h5: 's',
+    h6: 'xs'
+} as const;
+
 function determineFontSize(props: HeadlineProps) {
     const h1Styles = css`
         font-size: ${get('fontSizes.7')};
         line-height: 3.75rem;
     `;
 
-    switch (props.size) {
+    const size = props.size ?? DEFAULT_HEADLINE_SIZE[props.as];
+    switch (size) {
         case 'xxl':
             return h1Styles;
         case 'xl':
@@ -53,36 +63,6 @@ function determineFontSize(props: HeadlineProps) {
                 line-height: 1.25rem;
             `;
         case 'xs':
-            return css`
-                font-size: ${get('fontSizes.0')};
-                line-height: 1.125rem;
-            `;
-    }
-
-    switch (props.as) {
-        case 'h1':
-            return h1Styles;
-        case 'h2':
-            return css`
-                font-size: ${get('fontSizes.5')};
-                line-height: 2.5rem;
-            `;
-        case 'h3':
-            return css`
-                font-size: ${get('fontSizes.4')};
-                line-height: 2rem;
-            `;
-        case 'h4':
-            return css`
-                font-size: ${get('fontSizes.2')};
-                line-height: 1.375rem;
-            `;
-        case 'h5':
-            return css`
-                font-size: ${get('fontSizes.1')};
-                line-height: 1.25rem;
-            `;
-        case 'h6':
             return css`
                 font-size: ${get('fontSizes.0')};
                 line-height: 1.125rem;

--- a/src/components/Headline/Headline.tsx
+++ b/src/components/Headline/Headline.tsx
@@ -17,7 +17,10 @@ interface HeadlineProps
      * Set the html tag for the headline including the appropriate styles
      */
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-    size?: 'medium';
+    /**
+     * Set the style of the headline
+     */
+    size?: 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs';
 }
 
 function determineFontSize(props: HeadlineProps) {
@@ -27,10 +30,32 @@ function determineFontSize(props: HeadlineProps) {
     `;
 
     switch (props.size) {
-        case 'medium':
+        case 'xxl':
+            return h1Styles;
+        case 'xl':
+            return css`
+                font-size: ${get('fontSizes.5')};
+                line-height: 2.5rem;
+            `;
+        case 'l':
             return css`
                 font-size: ${get('fontSizes.4')};
                 line-height: 2rem;
+            `;
+        case 'm':
+            return css`
+                font-size: ${get('fontSizes.2')};
+                line-height: 1.375rem;
+            `;
+        case 's':
+            return css`
+                font-size: ${get('fontSizes.1')};
+                line-height: 1.25rem;
+            `;
+        case 'xs':
+            return css`
+                font-size: ${get('fontSizes.0')};
+                line-height: 1.125rem;
             `;
     }
 

--- a/src/components/Headline/docs/Headline.mdx
+++ b/src/components/Headline/docs/Headline.mdx
@@ -7,19 +7,29 @@ route: /components/headline
 import { Playground } from 'docz';
 import { ItemWrapper } from '../../../../docs/components/ItemWrapper.ts';
 import { Headline } from '../Headline.tsx';
-import { theme } from '../../../essentials/theme.ts';
-import { Colors } from '../../../essentials/Colors/Colors.ts';
+import { HeadlinePropsTable } from './HeadlinePropsTable';
+
 
 # Headline
 
-The Headline component will render an html `h1-6` tag. Please reference the
+The Headline component will render a html `h1-6` tag. Please reference the
 [w3 recommendations for headings](https://www.w3.org/WAI/tutorials/page-structure/headings/) to ensure your headings
 provide an accessible experience for screen reader users.
 
+Prefer to use headlines starting from level one and not skip levels. Use combination of `as` and `size` property to keep
+the semantics while following the design.
+
 -   Use different headlines and paragraphs to structure your content hierarchically
--   Avoid using headline lengths, breaking more then two times (three times on mobile)
+-   Avoid using headline lengths, breaking more than two times (three times on mobile)
 -   Avoid using sizes outside the given range
 -   Recommended width of headline is between 500px and 700px
+
+## Properties
+
+<HeadlinePropsTable />
+
+
+## Default headlines
 
 <ItemWrapper>
     <Headline as="h1">headline h1</Headline>
@@ -54,4 +64,5 @@ provide an accessible experience for screen reader users.
 
 <Playground>
     <Headline as="h3">default headline h3</Headline>
+    <Headline as="h1" size="xs">The smallest h1</Headline>
 </Playground>

--- a/src/components/Headline/docs/Headline.mdx
+++ b/src/components/Headline/docs/Headline.mdx
@@ -12,7 +12,7 @@ import { HeadlinePropsTable } from './HeadlinePropsTable';
 
 # Headline
 
-The Headline component will render a html `h1-6` tag. Please reference the
+The Headline component will render an html `h1-6` tag. Please reference the
 [w3 recommendations for headings](https://www.w3.org/WAI/tutorials/page-structure/headings/) to ensure your headings
 provide an accessible experience for screen reader users.
 
@@ -60,7 +60,7 @@ the semantics while following the design.
     </Headline>
 </ItemWrapper>
 
-### Playground
+## Examples
 
 <Playground>
     <Headline as="h3">default headline h3</Headline>

--- a/src/components/Headline/docs/HeadlinePropsTable.tsx
+++ b/src/components/Headline/docs/HeadlinePropsTable.tsx
@@ -11,7 +11,7 @@ export const HeadlinePropsTable = () => {
         {
             name: 'size',
             type: '"xxl" | "xl" | "l" | "m" | "s" | "xs"',
-            defaultValue: `depends on the heading level`
+            description: `if "size" prop is not set , the size is determined based on "as" prop`
         }
     ];
 

--- a/src/components/Headline/docs/HeadlinePropsTable.tsx
+++ b/src/components/Headline/docs/HeadlinePropsTable.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { PropsTable } from '../../../docs/PropsTable';
+
+export const HeadlinePropsTable = () => {
+    const props = [
+        {
+            name: 'as',
+            type: '"h1" | "h2" | "h3" | "h4" | "h5" | "h6"',
+            defaultValue: 'h1'
+        },
+        {
+            name: 'size',
+            type: '"xxl" | "xl" | "l" | "m" | "s" | "xs"',
+            defaultValue: `depends on the heading level`
+        }
+    ];
+
+    return <PropsTable props={props} />;
+};


### PR DESCRIPTION
**What:**
Allow influencing the size without changing the headline level.
​
**Why:**
Closes #17 

**How:**
Expose the `size` prop which takes precedence over the default headline level style
​
**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This is not a breaking change. The components without `size` prop set will still behave as in previous versions