### PR TITLE
fix: allow props to change the inline spinner again

### DIFF
--- a/src/components/InlineSpinner/InlineSpinner.tsx
+++ b/src/components/InlineSpinner/InlineSpinner.tsx
@@ -36,7 +36,7 @@ const rotation = keyframes`
     }
 `;
 
-const InlineSpinner: React.FC<InlineSpinnerProps> = styled.span<InlineSpinnerProps>`
+const InlineSpinnerIcon: React.FC<InlineSpinnerProps> = styled.div<InlineSpinnerProps>`
     display: inline-block;
     box-sizing: border-box;
     width: 1.25rem;
@@ -49,6 +49,12 @@ const InlineSpinner: React.FC<InlineSpinnerProps> = styled.span<InlineSpinnerPro
 
     ${compose(margin, sizeVariant)}
 `;
+
+const InlineSpinner = (props: InlineSpinnerProps) => (
+    <span>
+        <InlineSpinnerIcon {...props} />
+    </span>
+);
 
 InlineSpinner.defaultProps = {
     color: Colors.AUTHENTIC_BLUE_900,

--- a/src/components/InlineSpinner/InlineSpinner.tsx
+++ b/src/components/InlineSpinner/InlineSpinner.tsx
@@ -36,7 +36,7 @@ const rotation = keyframes`
     }
 `;
 
-const InlineSpinnerIcon: React.FC<InlineSpinnerProps> = styled.div<InlineSpinnerProps>`
+const InlineSpinner: React.FC<InlineSpinnerProps> = styled.span<InlineSpinnerProps>`
     display: inline-block;
     box-sizing: border-box;
     width: 1.25rem;
@@ -49,12 +49,6 @@ const InlineSpinnerIcon: React.FC<InlineSpinnerProps> = styled.div<InlineSpinner
 
     ${compose(margin, sizeVariant)}
 `;
-
-const InlineSpinner = () => (
-    <span>
-        <InlineSpinnerIcon />
-    </span>
-);
 
 InlineSpinner.defaultProps = {
     color: Colors.AUTHENTIC_BLUE_900,

--- a/src/components/InlineSpinner/__snapshots__/InlineSpinner.spec.tsx.snap
+++ b/src/components/InlineSpinner/__snapshots__/InlineSpinner.spec.tsx.snap
@@ -17,10 +17,12 @@ exports[`InlineSpinner renders in a custom color 1`] = `
   border-width: 0.125rem;
 }
 
-<span
-  class="c0"
-  color="#069D4F"
-/>
+<span>
+  <div
+    class="c0"
+    color="#069D4F"
+  />
+</span>
 `;
 
 exports[`InlineSpinner renders the default variant 1`] = `
@@ -40,10 +42,12 @@ exports[`InlineSpinner renders the default variant 1`] = `
   border-width: 0.125rem;
 }
 
-<span
-  class="c0"
-  color="#001E3E"
-/>
+<span>
+  <div
+    class="c0"
+    color="#001E3E"
+  />
+</span>
 `;
 
 exports[`InlineSpinner renders the small size 1`] = `
@@ -63,8 +67,10 @@ exports[`InlineSpinner renders the small size 1`] = `
   border-width: 0.1rem;
 }
 
-<span
-  class="c0"
-  color="#001E3E"
-/>
+<span>
+  <div
+    class="c0"
+    color="#001E3E"
+  />
+</span>
 `;

--- a/src/components/InlineSpinner/__snapshots__/InlineSpinner.spec.tsx.snap
+++ b/src/components/InlineSpinner/__snapshots__/InlineSpinner.spec.tsx.snap
@@ -7,18 +7,20 @@ exports[`InlineSpinner renders in a custom color 1`] = `
   width: 1.25rem;
   height: 1.25rem;
   vertical-align: text-bottom;
-  border: 0.125rem solid;
+  border: 0.125rem solid #069D4F;
   border-right-color: transparent;
   border-radius: 50%;
   -webkit-animation: wdnds 750ms linear infinite;
   animation: wdnds 750ms linear infinite;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-width: 0.125rem;
 }
 
-<span>
-  <div
-    class="c0"
-  />
-</span>
+<span
+  class="c0"
+  color="#069D4F"
+/>
 `;
 
 exports[`InlineSpinner renders the default variant 1`] = `
@@ -28,18 +30,20 @@ exports[`InlineSpinner renders the default variant 1`] = `
   width: 1.25rem;
   height: 1.25rem;
   vertical-align: text-bottom;
-  border: 0.125rem solid;
+  border: 0.125rem solid #001E3E;
   border-right-color: transparent;
   border-radius: 50%;
   -webkit-animation: wdnds 750ms linear infinite;
   animation: wdnds 750ms linear infinite;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-width: 0.125rem;
 }
 
-<span>
-  <div
-    class="c0"
-  />
-</span>
+<span
+  class="c0"
+  color="#001E3E"
+/>
 `;
 
 exports[`InlineSpinner renders the small size 1`] = `
@@ -49,16 +53,18 @@ exports[`InlineSpinner renders the small size 1`] = `
   width: 1.25rem;
   height: 1.25rem;
   vertical-align: text-bottom;
-  border: 0.125rem solid;
+  border: 0.125rem solid #001E3E;
   border-right-color: transparent;
   border-radius: 50%;
   -webkit-animation: wdnds 750ms linear infinite;
   animation: wdnds 750ms linear infinite;
+  width: 1rem;
+  height: 1rem;
+  border-width: 0.1rem;
 }
 
-<span>
-  <div
-    class="c0"
-  />
-</span>
+<span
+  class="c0"
+  color="#001E3E"
+/>
 `;


### PR DESCRIPTION
**What:**
Re-enable all props for the InlineSpinner component and fixed the tests, so we don't break it again 👀 
​
**Why:**
We introduced a wrapper element for the InlineSpinner in #77, but didn't forward the props for margin and size. This resulted in typescript projects that set the margin to break. All other projects would simply lose their set margins and sizes. @nlopin already found the issue with the sizes in #95, which this PR closes as well.
​
**How:**
Instead of wrapping the `div` element with `span`, we set the original element to `span`.
​
**Checklist:**
- [x] Ready to be merged

