### PR TITLE
docs: remove badly generated changelog title

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,33 +1,9 @@
-
----
-name: Changelog
-route: /changelog
----
-import { TitleCard } from './components/TitleCard';
-
-<TitleCard title="Release Notes">
-    Keep up to date with the latest releases of the design system.
-</TitleCard>
-
-
-
 ### [1.2.1](https://github.com/freenowtech/wave/compare/v1.2.0...v1.2.1) (2021-06-04)
 
 
 ### Bug Fixes
 
 * **password:** allow to set width of the password input ([#101](https://github.com/freenowtech/wave/issues/101)) ([17d9a9a](https://github.com/freenowtech/wave/commit/17d9a9a338f3769ac02e6a1537271bf6d37ca081))
-
----
-name: Changelog
-route: /changelog
----
-import { TitleCard } from './components/TitleCard';
-
-<TitleCard title="Release Notes">
-    Keep up to date with the latest releases of the design system.
-</TitleCard>
-
 
 
 ## [1.2.0](https://github.com/freenowtech/wave/compare/v1.1.0...v1.2.0) (2021-06-03)
@@ -41,17 +17,6 @@ import { TitleCard } from './components/TitleCard';
 ### Bug Fixes
 
 * **checkbox:** Adds disabled checkbox text color ([#97](https://github.com/freenowtech/wave/issues/97)) ([d2dc31d](https://github.com/freenowtech/wave/commit/d2dc31db1323e3947bb95139f80e02db5599a928))
-
----
-name: Changelog
-route: /changelog
----
-import { TitleCard } from './components/TitleCard';
-
-<TitleCard title="Release Notes">
-    Keep up to date with the latest releases of the design system.
-</TitleCard>
-
 
 
 ## [1.1.0](https://github.com/freenowtech/wave/compare/v1.0.7...v1.1.0) (2021-05-31)

--- a/release.config.js
+++ b/release.config.js
@@ -1,16 +1,3 @@
-const changelogTitle = `
----
-name: Changelog
-route: /changelog
----
-import { TitleCard } from './components/TitleCard';
-
-<TitleCard title="Release Notes">
-    Keep up to date with the latest releases of the design system.
-</TitleCard>
-
-`;
-
 module.exports = {
     branches: ['main'],
     plugins: [
@@ -29,8 +16,7 @@ module.exports = {
         [
             '@semantic-release/changelog',
             {
-                changelogFile: 'docs/changelog.mdx',
-                changelogTitle: changelogTitle
+                changelogFile: 'docs/changelog.mdx'
             }
         ],
         [


### PR DESCRIPTION
**What:**
Remove the auto-generate changelog title from the semantic-release/changelog plugin, fixes (partly) #106.
​
**Why:**
With the introduction of semantic-release, we moved the changelog generation to the automated process. Currently it (wrongly) adds the changelog title field for every changelog entry, leading to a broken build of the documentation.
​
**How:**
Removing the generated header will allow the changelog file to just contain markdown, which will not lead to build issues.
​
**Media:**
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/8927747/121151264-7dde8b00-c844-11eb-9d66-53eba063b1f1.png">

**Checklist:**

- [x] Ready to be merged