### PR TITLE
fix: preventing double clicks for the checkboxes

### DIFF
--- a/src/components/Checkbox/Checkbox.spec.tsx
+++ b/src/components/Checkbox/Checkbox.spec.tsx
@@ -1,4 +1,6 @@
 import { render } from '@testing-library/react';
+import user from '@testing-library/user-event';
+
 import * as React from 'react';
 import { Checkbox } from './Checkbox';
 
@@ -37,5 +39,18 @@ describe('Checkbox', () => {
 
     it('renders large checkbox', () => {
         expect(render(<Checkbox size="large" />).container.firstChild).toMatchSnapshot();
+    });
+
+    it('selects/unselects the checkbox on clicking the label', () => {
+        const labelText = 'Click Me!';
+        const onClickCallback = jest.fn();
+        const checkbox = render(<Checkbox label={labelText} onChange={e => onClickCallback(e.target.checked)} />);
+        const label = checkbox.getByText(labelText);
+
+        user.click(label);
+        expect(onClickCallback).toBeCalledWith(true);
+
+        user.click(label);
+        expect(onClickCallback).toBeCalledWith(false);
     });
 });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -50,7 +50,7 @@ const Checkbox: FC<CheckboxProps> = props => {
 
     if (typeof label === 'string') {
         dynamicLabel = (
-            <Text disabled={disabled} fontSize={size}>
+            <Text onClick={e => e.stopPropagation()} disabled={disabled} fontSize={size}>
                 {label}
             </Text>
         );


### PR DESCRIPTION


**What:**
<!-- Declarative and short sentence of what this PR accomplish -->
​This PR intends to fix an issue with checkboxes, where two clicks are registered instead of one
**Why:**
<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
​This was causing weird behavior with Google Tag Manager data capturing, and so I decided to investigate. The issue seems to be because of a click being registered on the inner `Text` component
**How:**
<!-- Often a list of things to describe the process to accomplish this PR -->
​Prevent the event from being propogated in order to fix this issue
**Media:**
<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->
https://www.loom.com/share/05dffc1f667d435b9bfdbba4c3dd1ee7
**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
