### PR TITLE
fix: emitting input click events for datepicker

### DIFF
--- a/src/components/Datepicker/DatepickerRangeInput.tsx
+++ b/src/components/Datepicker/DatepickerRangeInput.tsx
@@ -322,7 +322,6 @@ const DatepickerRangeInput = ({
                             onBlur={() => setFocusedInput(null)}
                             value={inputText.startText}
                             width="100%"
-                            onClick={e => e.stopPropagation()}
                             onChange={handleStartDateInputChange}
                             data-error={error.startDate}
                         />
@@ -338,7 +337,6 @@ const DatepickerRangeInput = ({
                             onFocus={() => setFocusedInput(!value.startDate ? START_DATE : END_DATE)}
                             onBlur={() => setFocusedInput(null)}
                             value={inputText.endText}
-                            onClick={e => e.stopPropagation()}
                             onChange={handleEndDateInputChange}
                             width="100%"
                             data-error={error.endDate}

--- a/src/components/Datepicker/DatepickerSingleInput.tsx
+++ b/src/components/Datepicker/DatepickerSingleInput.tsx
@@ -162,7 +162,6 @@ const DatepickerSingleInput = ({
                             placeholder={placeholder}
                             value={inputText}
                             onFocus={() => setIsFocused(true)}
-                            onClick={e => e.stopPropagation()}
                             onBlur={handleDatepickerClose}
                             onChange={handleDateTextChange}
                             data-error={error}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**
<!-- Declarative and short sentence of what this PR accomplish -->
​This PR enables emitting the click event on input fields inside the `Datepicker` component, for both (single and range) variants.

**Why:**
<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
​This is to keep in line with expected behavior, as datepicker components consist of an input field or two, depending on the variant, and so must detect the click.
**How:**
<!-- Often a list of things to describe the process to accomplish this PR -->
​Remove the `event.stopPropagation()` method call from the `Input` component `onClick` attribute
**Media:**
<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->
https://www.loom.com/share/29d22680ca7e4db0a9d16036996a7f71
**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
