### PR TITLE
Feat: side (left/right) modal

### DIFF
--- a/src/components/Modal/Modal.spec.tsx
+++ b/src/components/Modal/Modal.spec.tsx
@@ -12,6 +12,14 @@ describe('Modal', () => {
         expect(render(<Modal fullscreen>Content</Modal>).container).toMatchSnapshot();
     });
 
+    it('renders the left side variation', () => {
+        expect(render(<Modal side="left">Content</Modal>).container).toMatchSnapshot();
+    });
+
+    it('renders the right side variation', () => {
+        expect(render(<Modal side="right">Content</Modal>).container).toMatchSnapshot();
+    });
+
     describe('should call onClose function', () => {
         it('when clicking on close icon', async () => {
             const mockCloseHandler = jest.fn();

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -3,6 +3,7 @@ import { createGlobalStyle } from 'styled-components';
 import { WidthProps } from 'styled-system';
 import { useIsEscKeyPressed } from '../../utils/hooks/useIsEscKeyPressed';
 import { ANIMATION_DURATION as CARD_ANIMATION_DURATION, CenteredCard } from './components/CenteredCard';
+import { ANIMATION_DURATION as CARD_ANIMATION_DURATION_SIDE, SideCard } from './components/SideCard';
 import { ANIMATION_DURATION as DIMMING_ANIMATION_DURATION, DimmingFade } from './components/DimmingFade';
 import { TopRightXIcon } from './components/TopRightXIcon';
 
@@ -25,6 +26,10 @@ interface ModalProps extends WidthProps {
      * Show the modal covering the whole page to focus the users attention
      */
     fullscreen?: boolean;
+    /**
+     * Show the modal on the side of the page: left or right
+     */
+    side?: 'left' | 'right';
     /**
      * Makes the modal dismissible by the user (defaults to true)
      */
@@ -53,7 +58,7 @@ const ANIMATION_DURATION = Math.max(DIMMING_ANIMATION_DURATION, CARD_ANIMATION_D
  * when only using `React.FC<ModalProps>`. This leads to compiler errors when passing the
  * dismiss function.
  */
-const Modal: React.FC<ModalProps> = ({ children, onClose, dismissible, ...rest }: ModalProps) => {
+const Modal: React.FC<ModalProps> = ({ children, onClose, dismissible, side, ...rest }: ModalProps) => {
     const [visible, setVisible] = useState(true);
     const isEscKeyPressed = useIsEscKeyPressed();
 
@@ -95,10 +100,19 @@ const Modal: React.FC<ModalProps> = ({ children, onClose, dismissible, ...rest }
             >
                 {dismissible && rest.fullscreen && <TopRightXIcon data-testid="close-icon" onClick={handleClose} />}
             </DimmingFade>
-            <CenteredCard visible={visible} {...rest}>
-                {dismissible && !rest.fullscreen && <TopRightXIcon data-testid="close-icon" onClick={handleClose} />}
-                {renderChildren()}
-            </CenteredCard>
+            {side && !rest.fullscreen ? (
+                <SideCard visible={visible} {...rest} side={side}>
+                    {dismissible && <TopRightXIcon data-testid="close-icon" onClick={handleClose} />}
+                    {renderChildren()}
+                </SideCard>
+            ) : (
+                <CenteredCard visible={visible} {...rest}>
+                    {dismissible && !rest.fullscreen && (
+                        <TopRightXIcon data-testid="close-icon" onClick={handleClose} />
+                    )}
+                    {renderChildren()}
+                </CenteredCard>
+            )}
             <PreventBackgroundScroll />
         </DismissContext.Provider>
     );

--- a/src/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -103,7 +103,7 @@ exports[`Modal renders the default props 1`] = `
 
 <div>
   <div
-    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
     data-testid="dimming-background"
   />
   <div
@@ -234,7 +234,7 @@ exports[`Modal renders the fullscreen variation 1`] = `
 
 <div>
   <div
-    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
     data-testid="dimming-background"
   >
     <svg
@@ -256,6 +256,266 @@ exports[`Modal renders the fullscreen variation 1`] = `
     class="sc-AxjAm c2 centered-card-animation-appear centered-card-animation-appear-active"
     width="37.5rem"
   >
+    Content
+  </div>
+</div>
+`;
+
+exports[`Modal renders the left side variation 1`] = `
+.c1 {
+  overflow: auto;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.125rem;
+  padding: 2.5rem;
+  width: 28.375rem;
+  box-shadow: 0 0 0.75rem 0.25rem rgba(0,0,0,0.12);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: unset;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+  z-index: 1100;
+  height: 100%;
+  will-change: transform,opacity;
+  -webkit-transition: -webkit-transform 150ms ease-out,opacity 150ms ease-out;
+  -webkit-transition: transform 150ms ease-out,opacity 150ms ease-out;
+  transition: transform 150ms ease-out,opacity 150ms ease-out;
+}
+
+.c1.centered-card-animation-appear,
+.c1.centered-card-animation-enter {
+  opacity: 0;
+  -webkit-transform: translate(calc(-50% - 1rem),0%);
+  -ms-transform: translate(calc(-50% - 1rem),0%);
+  transform: translate(calc(-50% - 1rem),0%);
+}
+
+.c1.centered-card-animation-appear-active,
+.c1.centered-card-animation-enter-active {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit-done,
+.c1.centered-card-animation-exit-active {
+  opacity: 0;
+  -webkit-transform: translate(-10%,0%);
+  -ms-transform: translate(-10%,0%);
+  transform: translate(-10%,0%);
+}
+
+.c0 {
+  background-color: #000F1F;
+  height: 100%;
+  left: 0;
+  opacity: 0.6;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  will-change: opacity;
+  -webkit-transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+  transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+}
+
+.c0.dimming-fade-animation-appear,
+.c0.dimming-fade-animation-enter {
+  opacity: 0;
+}
+
+.c0.dimming-fade-animation-appear-active,
+.c0.dimming-fade-animation-enter-active {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit-done,
+.c0.dimming-fade-animation-exit-active {
+  opacity: 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 1100;
+}
+
+@media (max-width:calc(28.375rem + 2rem)) {
+  .c1 {
+    width: calc(100% - 2rem);
+  }
+}
+
+<div>
+  <div
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    data-testid="dimming-background"
+  />
+  <div
+    class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
+    width="28.375rem"
+  >
+    <svg
+      class="c2"
+      color="#001E3E"
+      data-testid="close-icon"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+    Content
+  </div>
+</div>
+`;
+
+exports[`Modal renders the right side variation 1`] = `
+.c1 {
+  overflow: auto;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.125rem;
+  padding: 2.5rem;
+  width: 28.375rem;
+  box-shadow: 0 0 0.75rem 0.25rem rgba(0,0,0,0.12);
+  position: fixed;
+  top: 0;
+  left: unset;
+  right: 0;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+  z-index: 1100;
+  height: 100%;
+  will-change: transform,opacity;
+  -webkit-transition: -webkit-transform 150ms ease-out,opacity 150ms ease-out;
+  -webkit-transition: transform 150ms ease-out,opacity 150ms ease-out;
+  transition: transform 150ms ease-out,opacity 150ms ease-out;
+}
+
+.c1.centered-card-animation-appear,
+.c1.centered-card-animation-enter {
+  opacity: 0;
+  -webkit-transform: translate(calc(50% + 1rem),0%);
+  -ms-transform: translate(calc(50% + 1rem),0%);
+  transform: translate(calc(50% + 1rem),0%);
+}
+
+.c1.centered-card-animation-appear-active,
+.c1.centered-card-animation-enter-active {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit-done,
+.c1.centered-card-animation-exit-active {
+  opacity: 0;
+  -webkit-transform: translate(+10%,0%);
+  -ms-transform: translate(+10%,0%);
+  transform: translate(+10%,0%);
+}
+
+.c0 {
+  background-color: #000F1F;
+  height: 100%;
+  left: 0;
+  opacity: 0.6;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  will-change: opacity;
+  -webkit-transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+  transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+}
+
+.c0.dimming-fade-animation-appear,
+.c0.dimming-fade-animation-enter {
+  opacity: 0;
+}
+
+.c0.dimming-fade-animation-appear-active,
+.c0.dimming-fade-animation-enter-active {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit-done,
+.c0.dimming-fade-animation-exit-active {
+  opacity: 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 1100;
+}
+
+@media (max-width:calc(28.375rem + 2rem)) {
+  .c1 {
+    width: calc(100% - 2rem);
+  }
+}
+
+<div>
+  <div
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    data-testid="dimming-background"
+  />
+  <div
+    class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
+    width="28.375rem"
+  >
+    <svg
+      class="c2"
+      color="#001E3E"
+      data-testid="close-icon"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
     Content
   </div>
 </div>

--- a/src/components/Modal/components/SideCard.tsx
+++ b/src/components/Modal/components/SideCard.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { CSSTransition } from 'react-transition-group';
+import styled, { css } from 'styled-components';
+import { Elevation } from '../../../essentials';
+import { Card, CardProps } from '../../Card/Card';
+
+const ANIMATION_DURATION = 150;
+const TRANSITION_KEY = 'centered-card-animation';
+
+const fromLeft = css`
+    &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+        opacity: 0;
+        transform: translate(calc(-50% - 1rem), 0%);
+    }
+
+    &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+        opacity: 0;
+        transform: translate(-10%, 0%);
+    }
+`;
+
+const fromRight = css`
+    &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+        opacity: 0;
+        transform: translate(calc(50% + 1rem), 0%);
+    }
+
+    &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+        opacity: 0;
+        transform: translate(+10%, 0%);
+    }
+`;
+
+const StyledCard = styled(Card)<{ side?: string }>`
+    position: fixed;
+    top: 0;
+    left: ${p => (p.side === 'right' ? 'unset' : 0)};
+    right: ${p => (p.side === 'right' ? 0 : 'unset')};
+    transform: translate(0%, 0%);
+    z-index: ${Elevation.CARD_ON_DIMMING};
+    height: 100%;
+    will-change: transform, opacity;
+    transition: transform ${ANIMATION_DURATION}ms ease-out, opacity ${ANIMATION_DURATION}ms ease-out;
+
+    ${p => (p.side === 'right' ? fromRight : fromLeft)};
+
+    @media (max-width: calc(${p => p.width} + 2rem)) {
+        width: calc(100% - 2rem);
+    }
+`;
+
+const SideCard: React.FC<CardProps & { visible: boolean; side: string }> = ({
+    visible,
+    width = '28.375rem',
+    ...rest
+}) => {
+    return (
+        <CSSTransition in={visible} classNames={TRANSITION_KEY} timeout={ANIMATION_DURATION} unmountOnExit appear>
+            <StyledCard {...rest} width={width} level={300} />
+        </CSSTransition>
+    );
+};
+
+export { SideCard, ANIMATION_DURATION };

--- a/src/components/Modal/docs/ModalCreator.tsx
+++ b/src/components/Modal/docs/ModalCreator.tsx
@@ -18,6 +18,8 @@ const modalContent = dismiss => (
 enum ModalType {
     NONE,
     DEFAULT,
+    LEFT,
+    RIGHT,
     FULLSCREEN,
     NON_DISMISSIBLE
 }
@@ -38,6 +40,12 @@ const ModalCreator = () => {
             <Button size="small" mr={1} onClick={openModal(ModalType.DEFAULT)}>
                 Default Modal
             </Button>
+            <Button size="small" mr={1} onClick={openModal(ModalType.LEFT)}>
+                Left Modal
+            </Button>
+            <Button size="small" mr={1} onClick={openModal(ModalType.RIGHT)}>
+                Right Modal
+            </Button>
             <Button size="small" mr={1} onClick={openModal(ModalType.FULLSCREEN)}>
                 Fullscreen Modal
             </Button>
@@ -46,6 +54,16 @@ const ModalCreator = () => {
             </Button>
 
             {modal == ModalType.DEFAULT && <Modal onClose={hideModal}>{modalContent}</Modal>}
+            {modal == ModalType.LEFT && (
+                <Modal side="left" onClose={hideModal}>
+                    {modalContent}
+                </Modal>
+            )}
+            {modal == ModalType.RIGHT && (
+                <Modal side="right" onClose={hideModal}>
+                    {modalContent}
+                </Modal>
+            )}
             {modal == ModalType.FULLSCREEN && (
                 <Modal onClose={hideModal} fullscreen>
                     {modalContent}

--- a/src/components/Modal/docs/ModalPropsTable.tsx
+++ b/src/components/Modal/docs/ModalPropsTable.tsx
@@ -10,6 +10,12 @@ export const ModalPropsTable = () => {
             defaultValue: 'false'
         },
         {
+            name: 'side',
+            type: '"left" | "right"',
+            description: 'Show the modal on the side of the page: left or right.',
+            defaultValue: '-'
+        },
+        {
             name: 'dismissible',
             type: 'boolean',
             description: 'Makes the modal dismissible by the user.',


### PR DESCRIPTION
**What:**
Add a side (left/right) modal card.
​
**Why:**
We need a side modal for this [design](https://app.zeplin.io/project/57fe438f81b870887cc71736/screen/60900157d95163088c092d08).
​
**How:**
Add a new component `SideCard` which renders when it receives the side props ("left" | "right") and slides from the relative side.
​
**Media:**
![wVGHMtm3UL](https://user-images.githubusercontent.com/12762609/121492455-30465780-c9d7-11eb-8a21-d9104541d8d6.gif)

See more in this video on [loom](https://www.loom.com/share/2a8bca6293a6499ba79f8cc25913e5c1)

**Checklist:**

- [ ] Ready to be merged
