### PR TITLE
Feat/offcanvas

### DIFF
--- a/src/components/Offcanvas/Offcanvas.spec.tsx
+++ b/src/components/Offcanvas/Offcanvas.spec.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { Offcanvas, useOffcanvasDismiss } from './Offcanvas';
+
+describe('Offcanvas', () => {
+    it('renders the default props', () => {
+        expect(render(<Offcanvas>Content</Offcanvas>).container).toMatchSnapshot();
+    });
+
+    it('renders the left side variation', () => {
+        expect(render(<Offcanvas side="left">Content</Offcanvas>).container).toMatchSnapshot();
+    });
+
+    it('renders the right side variation', () => {
+        expect(render(<Offcanvas side="right">Content</Offcanvas>).container).toMatchSnapshot();
+    });
+
+    describe('should call onClose function', () => {
+        it('when clicking on close icon', async () => {
+            const mockCloseHandler = jest.fn();
+            const { getByTestId } = render(<Offcanvas onClose={mockCloseHandler}>Content</Offcanvas>);
+
+            fireEvent.click(getByTestId('close-icon'));
+
+            await waitFor(() => expect(mockCloseHandler).toHaveBeenCalled());
+        });
+
+        it('when clicking on the dimming background', async () => {
+            const mockCloseHandler = jest.fn();
+            const { getByTestId } = render(<Offcanvas onClose={mockCloseHandler}>Content</Offcanvas>);
+
+            fireEvent.click(getByTestId('dimming-background'));
+
+            await waitFor(() => expect(mockCloseHandler).toHaveBeenCalled());
+        });
+
+        it('when pressing the escape key', async () => {
+            const mockCloseHandler = jest.fn();
+            render(<Offcanvas onClose={mockCloseHandler}>Content</Offcanvas>);
+
+            fireEvent.keyUp(window, { keyCode: 27 });
+
+            await waitFor(() => expect(mockCloseHandler).toHaveBeenCalled());
+        });
+
+        it('when calling the dismiss function', async () => {
+            const mockCloseHandler = jest.fn();
+            const { getByTestId } = render(
+                <Offcanvas onClose={mockCloseHandler}>
+                    {dismiss => <button onClick={dismiss} data-testid="dismiss-button" />}
+                </Offcanvas>
+            );
+
+            fireEvent.click(getByTestId('dismiss-button'));
+
+            await waitFor(() => expect(mockCloseHandler).toHaveBeenCalled());
+        });
+
+        it('when calling the dismiss function from a hook', async () => {
+            const mockCloseHandler = jest.fn();
+
+            const InnerComponent: React.FC = () => {
+                const dismiss = useOffcanvasDismiss();
+                return <button onClick={dismiss}>Click Me</button>;
+            };
+
+            render(
+                <Offcanvas onClose={mockCloseHandler}>
+                    <InnerComponent />
+                </Offcanvas>
+            );
+
+            userEvent.click(screen.getByRole('button'));
+
+            await waitFor(() => expect(mockCloseHandler).toHaveBeenCalled());
+        });
+    });
+
+    describe('in the non-dismissible state', () => {
+        it('should not show the close icon for the default Offcanvas', () => {
+            const { queryByTestId } = render(<Offcanvas dismissible={false} />);
+
+            expect(queryByTestId('close-icon')).toBeNull();
+        });
+
+        it('should not call the onClose handler when clicking on the dimming', async () => {
+            const mockCloseHandler = jest.fn();
+            const { getByTestId } = render(<Offcanvas dismissible={false} onClose={mockCloseHandler} />);
+
+            fireEvent.click(getByTestId('dimming-background'));
+
+            await waitFor(() => expect(mockCloseHandler).not.toHaveBeenCalled());
+        });
+
+        it('should not call the onClose handler when pressing the escape key', async () => {
+            const mockCloseHandler = jest.fn();
+            render(
+                <Offcanvas dismissible={false} onClose={mockCloseHandler}>
+                    Content
+                </Offcanvas>
+            );
+
+            fireEvent.keyUp(window, { keyCode: 27 });
+
+            await waitFor(() => expect(mockCloseHandler).not.toHaveBeenCalled());
+        });
+
+        it('should call the onClose handler when calling the dismiss function', async () => {
+            const mockCloseHandler = jest.fn();
+            const { getByTestId } = render(
+                <Offcanvas onClose={mockCloseHandler} dismissible={false}>
+                    {dismiss => <button onClick={dismiss} data-testid="dismiss-button" />}
+                </Offcanvas>
+            );
+
+            fireEvent.click(getByTestId('dismiss-button'));
+
+            await waitFor(() => expect(mockCloseHandler).toHaveBeenCalled());
+        });
+    });
+});

--- a/src/components/Offcanvas/Offcanvas.spec.tsx
+++ b/src/components/Offcanvas/Offcanvas.spec.tsx
@@ -16,6 +16,14 @@ describe('Offcanvas', () => {
         expect(render(<Offcanvas side="right">Content</Offcanvas>).container).toMatchSnapshot();
     });
 
+    it('renders the top side variation', () => {
+        expect(render(<Offcanvas side="top">Content</Offcanvas>).container).toMatchSnapshot();
+    });
+
+    it('renders the bottom side variation', () => {
+        expect(render(<Offcanvas side="bottom">Content</Offcanvas>).container).toMatchSnapshot();
+    });
+
     describe('should call onClose function', () => {
         it('when clicking on close icon', async () => {
             const mockCloseHandler = jest.fn();

--- a/src/components/Offcanvas/Offcanvas.tsx
+++ b/src/components/Offcanvas/Offcanvas.tsx
@@ -47,7 +47,10 @@ const PreventBackgroundScroll = createGlobalStyle`
     }
 `;
 
-const ANIMATION_DURATION = Math.max(DIMMING_ANIMATION_DURATION, CARD_ANIMATION_DURATION | CARD_ANIMATION_DURATION_SIDE);
+const ANIMATION_DURATION = Math.max(
+    DIMMING_ANIMATION_DURATION,
+    CARD_ANIMATION_DURATION || CARD_ANIMATION_DURATION_SIDE
+);
 
 /*
  * We define the types for the props twice because the render props won't be inferred correctly

--- a/src/components/Offcanvas/Offcanvas.tsx
+++ b/src/components/Offcanvas/Offcanvas.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState, ReactNode, useContext } from 'react';
 import { createGlobalStyle } from 'styled-components';
 import { WidthProps } from 'styled-system';
 import { useIsEscKeyPressed } from '../../utils/hooks/useIsEscKeyPressed';
-import { ANIMATION_DURATION as CARD_ANIMATION_DURATION, SideCard } from './components/SideCard';
+import { ANIMATION_DURATION as CARD_ANIMATION_DURATION, CenteredCard } from './components/CenteredCard';
+import { ANIMATION_DURATION as CARD_ANIMATION_DURATION_SIDE, SideCard } from './components/SideCard';
 import { ANIMATION_DURATION as DIMMING_ANIMATION_DURATION, DimmingFade } from './components/DimmingFade';
 import { TopRightXIcon } from './components/TopRightXIcon';
 
@@ -46,14 +47,20 @@ const PreventBackgroundScroll = createGlobalStyle`
     }
 `;
 
-const ANIMATION_DURATION = Math.max(DIMMING_ANIMATION_DURATION, CARD_ANIMATION_DURATION);
+const ANIMATION_DURATION = Math.max(DIMMING_ANIMATION_DURATION, CARD_ANIMATION_DURATION | CARD_ANIMATION_DURATION_SIDE);
 
 /*
  * We define the types for the props twice because the render props won't be inferred correctly
  * when only using `React.FC<OffcanvasProps>`. This leads to compiler errors when passing the
  * dismiss function.
  */
-const Offcanvas: React.FC<OffcanvasProps> = ({ children, onClose, dismissible, side, ...rest }: OffcanvasProps) => {
+const Offcanvas: React.FC<OffcanvasProps> = ({
+    children,
+    onClose,
+    dismissible,
+    side = 'left',
+    ...rest
+}: OffcanvasProps) => {
     const [visible, setVisible] = useState(true);
     const isEscKeyPressed = useIsEscKeyPressed();
 
@@ -86,10 +93,17 @@ const Offcanvas: React.FC<OffcanvasProps> = ({ children, onClose, dismissible, s
     return (
         <DismissContext.Provider value={handleClose}>
             <DimmingFade onClick={handleDimmingClick} visible={visible} data-testid="dimming-background" />
-            <SideCard visible={visible} {...rest} side={side}>
-                {dismissible && <TopRightXIcon data-testid="close-icon" onClick={handleClose} />}
-                {renderChildren()}
-            </SideCard>
+            {side === 'top' || side === 'bottom' ? (
+                <CenteredCard visible={visible} {...rest} side={side}>
+                    {dismissible && <TopRightXIcon data-testid="close-icon" onClick={handleClose} />}
+                    {renderChildren()}
+                </CenteredCard>
+            ) : (
+                <SideCard visible={visible} {...rest} side={side}>
+                    {dismissible && <TopRightXIcon data-testid="close-icon" onClick={handleClose} />}
+                    {renderChildren()}
+                </SideCard>
+            )}
             <PreventBackgroundScroll />
         </DismissContext.Provider>
     );

--- a/src/components/Offcanvas/Offcanvas.tsx
+++ b/src/components/Offcanvas/Offcanvas.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState, ReactNode, useContext } from 'react';
+import { createGlobalStyle } from 'styled-components';
+import { WidthProps } from 'styled-system';
+import { useIsEscKeyPressed } from '../../utils/hooks/useIsEscKeyPressed';
+import { ANIMATION_DURATION as CARD_ANIMATION_DURATION, SideCard } from './components/SideCard';
+import { ANIMATION_DURATION as DIMMING_ANIMATION_DURATION, DimmingFade } from './components/DimmingFade';
+import { TopRightXIcon } from './components/TopRightXIcon';
+
+type DismissFunc = () => void;
+
+const DismissContext = React.createContext<DismissFunc>(undefined);
+
+const useOffcanvasDismiss = () => {
+    const dismiss = useContext(DismissContext);
+
+    if (dismiss === undefined) {
+        throw new Error('useOffcanvasDismiss must be used within a <Offcanvas />');
+    }
+
+    return dismiss;
+};
+
+interface OffcanvasProps extends WidthProps {
+    /**
+     * Show the Offcanvas on the side of the page: left or right
+     */
+    side?: 'left' | 'right' | 'top' | 'bottom';
+    /**
+     * Makes the Offcanvas dismissible by the user (defaults to true)
+     */
+    dismissible?: boolean;
+    /**
+     * Function that will be called when the user intends to close the Offcanvas
+     */
+    onClose?: () => void;
+    /**
+     * Children can be rendered with a dismiss function as render prop. Calling
+     * the dismiss function will close the Offcanvas.
+     */
+    children?: ReactNode | ((dismiss: DismissFunc) => ReactNode);
+}
+
+const PreventBackgroundScroll = createGlobalStyle`
+    body {
+        overflow: hidden;
+    }
+`;
+
+const ANIMATION_DURATION = Math.max(DIMMING_ANIMATION_DURATION, CARD_ANIMATION_DURATION);
+
+/*
+ * We define the types for the props twice because the render props won't be inferred correctly
+ * when only using `React.FC<OffcanvasProps>`. This leads to compiler errors when passing the
+ * dismiss function.
+ */
+const Offcanvas: React.FC<OffcanvasProps> = ({ children, onClose, dismissible, side, ...rest }: OffcanvasProps) => {
+    const [visible, setVisible] = useState(true);
+    const isEscKeyPressed = useIsEscKeyPressed();
+
+    const handleClose: DismissFunc = () => {
+        setVisible(false);
+
+        if (onClose) {
+            setTimeout(() => onClose(), ANIMATION_DURATION);
+        }
+    };
+
+    const handleDimmingClick = () => {
+        if (dismissible) handleClose();
+    };
+
+    useEffect(() => {
+        if (dismissible && isEscKeyPressed) {
+            handleClose();
+        }
+    }, [dismissible, isEscKeyPressed]);
+
+    const renderChildren = () => {
+        if (typeof children === 'function') {
+            return children(handleClose);
+        }
+
+        return children;
+    };
+
+    return (
+        <DismissContext.Provider value={handleClose}>
+            <DimmingFade onClick={handleDimmingClick} visible={visible} data-testid="dimming-background" />
+            <SideCard visible={visible} {...rest} side={side}>
+                {dismissible && <TopRightXIcon data-testid="close-icon" onClick={handleClose} />}
+                {renderChildren()}
+            </SideCard>
+            <PreventBackgroundScroll />
+        </DismissContext.Provider>
+    );
+};
+
+Offcanvas.defaultProps = {
+    dismissible: true
+};
+
+export { Offcanvas, OffcanvasProps, useOffcanvasDismiss };

--- a/src/components/Offcanvas/__snapshots__/Offcanvas.spec.tsx.snap
+++ b/src/components/Offcanvas/__snapshots__/Offcanvas.spec.tsx.snap
@@ -1,5 +1,138 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Offcanvas renders the bottom side variation 1`] = `
+.c1 {
+  overflow: auto;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.125rem;
+  padding: 2.5rem;
+  height: 28.375rem;
+  box-shadow: 0 0 0.75rem 0.25rem rgba(0,0,0,0.12);
+  position: fixed;
+  left: 0;
+  right: unset;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+  z-index: 1100;
+  width: 100%;
+  will-change: transform,opacity;
+  -webkit-transition: -webkit-transform 150ms ease-out,opacity 150ms ease-out;
+  -webkit-transition: transform 150ms ease-out,opacity 150ms ease-out;
+  transition: transform 150ms ease-out,opacity 150ms ease-out;
+  left: 0;
+  right: 0;
+  top: unset;
+  bottom: 0;
+}
+
+.c1.centered-card-animation-appear,
+.c1.centered-card-animation-enter {
+  opacity: 0;
+  -webkit-transform: translate(0%,calc(50% + 1rem));
+  -ms-transform: translate(0%,calc(50% + 1rem));
+  transform: translate(0%,calc(50% + 1rem));
+}
+
+.c1.centered-card-animation-appear-active,
+.c1.centered-card-animation-enter-active {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit-done,
+.c1.centered-card-animation-exit-active {
+  opacity: 0;
+  -webkit-transform: translate(0%,10%);
+  -ms-transform: translate(0%,10%);
+  transform: translate(0%,10%);
+}
+
+.c0 {
+  background-color: #000F1F;
+  height: 100%;
+  left: 0;
+  opacity: 0.6;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  will-change: opacity;
+  -webkit-transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+  transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+}
+
+.c0.dimming-fade-animation-appear,
+.c0.dimming-fade-animation-enter {
+  opacity: 0;
+}
+
+.c0.dimming-fade-animation-appear-active,
+.c0.dimming-fade-animation-enter-active {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit-done,
+.c0.dimming-fade-animation-exit-active {
+  opacity: 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 1100;
+}
+
+@media (max-width:calc( + 2rem)) {
+  .c1 {
+    width: calc(100% - 2rem);
+  }
+}
+
+<div>
+  <div
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    data-testid="dimming-background"
+  />
+  <div
+    class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
+    height="28.375rem"
+  >
+    <svg
+      class="c2"
+      color="#001E3E"
+      data-testid="close-icon"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+    Content
+  </div>
+</div>
+`;
+
 exports[`Offcanvas renders the default props 1`] = `
 .c1 {
   overflow: auto;
@@ -107,7 +240,7 @@ exports[`Offcanvas renders the default props 1`] = `
 
 <div>
   <div
-    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
     data-testid="dimming-background"
   />
   <div
@@ -240,7 +373,7 @@ exports[`Offcanvas renders the left side variation 1`] = `
 
 <div>
   <div
-    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
     data-testid="dimming-background"
   />
   <div
@@ -373,12 +506,145 @@ exports[`Offcanvas renders the right side variation 1`] = `
 
 <div>
   <div
-    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
     data-testid="dimming-background"
   />
   <div
     class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
     width="28.375rem"
+  >
+    <svg
+      class="c2"
+      color="#001E3E"
+      data-testid="close-icon"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+    Content
+  </div>
+</div>
+`;
+
+exports[`Offcanvas renders the top side variation 1`] = `
+.c1 {
+  overflow: auto;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.125rem;
+  padding: 2.5rem;
+  height: 28.375rem;
+  box-shadow: 0 0 0.75rem 0.25rem rgba(0,0,0,0.12);
+  position: fixed;
+  left: 0;
+  right: unset;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+  z-index: 1100;
+  width: 100%;
+  will-change: transform,opacity;
+  -webkit-transition: -webkit-transform 150ms ease-out,opacity 150ms ease-out;
+  -webkit-transition: transform 150ms ease-out,opacity 150ms ease-out;
+  transition: transform 150ms ease-out,opacity 150ms ease-out;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: unset;
+}
+
+.c1.centered-card-animation-appear,
+.c1.centered-card-animation-enter {
+  opacity: 0;
+  -webkit-transform: translate(0%,calc(-50% - 1rem));
+  -ms-transform: translate(0%,calc(-50% - 1rem));
+  transform: translate(0%,calc(-50% - 1rem));
+}
+
+.c1.centered-card-animation-appear-active,
+.c1.centered-card-animation-enter-active {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit-done,
+.c1.centered-card-animation-exit-active {
+  opacity: 0;
+  -webkit-transform: translate(-0%,-50%);
+  -ms-transform: translate(-0%,-50%);
+  transform: translate(-0%,-50%);
+}
+
+.c0 {
+  background-color: #000F1F;
+  height: 100%;
+  left: 0;
+  opacity: 0.6;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  will-change: opacity;
+  -webkit-transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+  transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+}
+
+.c0.dimming-fade-animation-appear,
+.c0.dimming-fade-animation-enter {
+  opacity: 0;
+}
+
+.c0.dimming-fade-animation-appear-active,
+.c0.dimming-fade-animation-enter-active {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit-done,
+.c0.dimming-fade-animation-exit-active {
+  opacity: 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 1100;
+}
+
+@media (max-width:calc( + 2rem)) {
+  .c1 {
+    width: calc(100% - 2rem);
+  }
+}
+
+<div>
+  <div
+    class="sc-AxhCb c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    data-testid="dimming-background"
+  />
+  <div
+    class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
+    height="28.375rem"
   >
     <svg
       class="c2"

--- a/src/components/Offcanvas/__snapshots__/Offcanvas.spec.tsx.snap
+++ b/src/components/Offcanvas/__snapshots__/Offcanvas.spec.tsx.snap
@@ -1,0 +1,400 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Offcanvas renders the default props 1`] = `
+.c1 {
+  overflow: auto;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.125rem;
+  padding: 2.5rem;
+  width: 28.375rem;
+  box-shadow: 0 0 0.75rem 0.25rem rgba(0,0,0,0.12);
+  position: fixed;
+  left: 0;
+  right: unset;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+  z-index: 1100;
+  height: 100%;
+  will-change: transform,opacity;
+  -webkit-transition: -webkit-transform 150ms ease-out,opacity 150ms ease-out;
+  -webkit-transition: transform 150ms ease-out,opacity 150ms ease-out;
+  transition: transform 150ms ease-out,opacity 150ms ease-out;
+  left: 0;
+  right: unset;
+  top: 0;
+  bottom: 0;
+}
+
+.c1.centered-card-animation-appear,
+.c1.centered-card-animation-enter {
+  opacity: 0;
+  -webkit-transform: translate(calc(-50% - 1rem),0%);
+  -ms-transform: translate(calc(-50% - 1rem),0%);
+  transform: translate(calc(-50% - 1rem),0%);
+}
+
+.c1.centered-card-animation-appear-active,
+.c1.centered-card-animation-enter-active {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit-done,
+.c1.centered-card-animation-exit-active {
+  opacity: 0;
+  -webkit-transform: translate(-10%,0%);
+  -ms-transform: translate(-10%,0%);
+  transform: translate(-10%,0%);
+}
+
+.c0 {
+  background-color: #000F1F;
+  height: 100%;
+  left: 0;
+  opacity: 0.6;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  will-change: opacity;
+  -webkit-transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+  transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+}
+
+.c0.dimming-fade-animation-appear,
+.c0.dimming-fade-animation-enter {
+  opacity: 0;
+}
+
+.c0.dimming-fade-animation-appear-active,
+.c0.dimming-fade-animation-enter-active {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit-done,
+.c0.dimming-fade-animation-exit-active {
+  opacity: 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 1100;
+}
+
+@media (max-width:calc(28.375rem + 2rem)) {
+  .c1 {
+    width: calc(100% - 2rem);
+  }
+}
+
+<div>
+  <div
+    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    data-testid="dimming-background"
+  />
+  <div
+    class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
+    width="28.375rem"
+  >
+    <svg
+      class="c2"
+      color="#001E3E"
+      data-testid="close-icon"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+    Content
+  </div>
+</div>
+`;
+
+exports[`Offcanvas renders the left side variation 1`] = `
+.c1 {
+  overflow: auto;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.125rem;
+  padding: 2.5rem;
+  width: 28.375rem;
+  box-shadow: 0 0 0.75rem 0.25rem rgba(0,0,0,0.12);
+  position: fixed;
+  left: 0;
+  right: unset;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+  z-index: 1100;
+  height: 100%;
+  will-change: transform,opacity;
+  -webkit-transition: -webkit-transform 150ms ease-out,opacity 150ms ease-out;
+  -webkit-transition: transform 150ms ease-out,opacity 150ms ease-out;
+  transition: transform 150ms ease-out,opacity 150ms ease-out;
+  left: 0;
+  right: unset;
+  top: 0;
+  bottom: 0;
+}
+
+.c1.centered-card-animation-appear,
+.c1.centered-card-animation-enter {
+  opacity: 0;
+  -webkit-transform: translate(calc(-50% - 1rem),0%);
+  -ms-transform: translate(calc(-50% - 1rem),0%);
+  transform: translate(calc(-50% - 1rem),0%);
+}
+
+.c1.centered-card-animation-appear-active,
+.c1.centered-card-animation-enter-active {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit-done,
+.c1.centered-card-animation-exit-active {
+  opacity: 0;
+  -webkit-transform: translate(-10%,0%);
+  -ms-transform: translate(-10%,0%);
+  transform: translate(-10%,0%);
+}
+
+.c0 {
+  background-color: #000F1F;
+  height: 100%;
+  left: 0;
+  opacity: 0.6;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  will-change: opacity;
+  -webkit-transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+  transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+}
+
+.c0.dimming-fade-animation-appear,
+.c0.dimming-fade-animation-enter {
+  opacity: 0;
+}
+
+.c0.dimming-fade-animation-appear-active,
+.c0.dimming-fade-animation-enter-active {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit-done,
+.c0.dimming-fade-animation-exit-active {
+  opacity: 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 1100;
+}
+
+@media (max-width:calc(28.375rem + 2rem)) {
+  .c1 {
+    width: calc(100% - 2rem);
+  }
+}
+
+<div>
+  <div
+    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    data-testid="dimming-background"
+  />
+  <div
+    class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
+    width="28.375rem"
+  >
+    <svg
+      class="c2"
+      color="#001E3E"
+      data-testid="close-icon"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+    Content
+  </div>
+</div>
+`;
+
+exports[`Offcanvas renders the right side variation 1`] = `
+.c1 {
+  overflow: auto;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.125rem;
+  padding: 2.5rem;
+  width: 28.375rem;
+  box-shadow: 0 0 0.75rem 0.25rem rgba(0,0,0,0.12);
+  position: fixed;
+  left: unset;
+  right: 0;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+  z-index: 1100;
+  height: 100%;
+  will-change: transform,opacity;
+  -webkit-transition: -webkit-transform 150ms ease-out,opacity 150ms ease-out;
+  -webkit-transition: transform 150ms ease-out,opacity 150ms ease-out;
+  transition: transform 150ms ease-out,opacity 150ms ease-out;
+  left: unset;
+  right: 0;
+  top: 0;
+  bottom: 0;
+}
+
+.c1.centered-card-animation-appear,
+.c1.centered-card-animation-enter {
+  opacity: 0;
+  -webkit-transform: translate(calc(50% + 1rem),0%);
+  -ms-transform: translate(calc(50% + 1rem),0%);
+  transform: translate(calc(50% + 1rem),0%);
+}
+
+.c1.centered-card-animation-appear-active,
+.c1.centered-card-animation-enter-active {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit {
+  opacity: 1;
+  -webkit-transform: translate(0%,0%);
+  -ms-transform: translate(0%,0%);
+  transform: translate(0%,0%);
+}
+
+.c1.centered-card-animation-exit-done,
+.c1.centered-card-animation-exit-active {
+  opacity: 0;
+  -webkit-transform: translate(+10%,0%);
+  -ms-transform: translate(+10%,0%);
+  transform: translate(+10%,0%);
+}
+
+.c0 {
+  background-color: #000F1F;
+  height: 100%;
+  left: 0;
+  opacity: 0.6;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  will-change: opacity;
+  -webkit-transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+  transition: opacity 200ms cubic-bezier(0.215,0.61,0.355,1);
+}
+
+.c0.dimming-fade-animation-appear,
+.c0.dimming-fade-animation-enter {
+  opacity: 0;
+}
+
+.c0.dimming-fade-animation-appear-active,
+.c0.dimming-fade-animation-enter-active {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit {
+  opacity: 0.6;
+}
+
+.c0.dimming-fade-animation-exit-done,
+.c0.dimming-fade-animation-exit-active {
+  opacity: 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 1100;
+}
+
+@media (max-width:calc(28.375rem + 2rem)) {
+  .c1 {
+    width: calc(100% - 2rem);
+  }
+}
+
+<div>
+  <div
+    class="sc-AxiKw c0 dimming-fade-animation-appear dimming-fade-animation-appear-active"
+    data-testid="dimming-background"
+  />
+  <div
+    class="sc-AxjAm c1 centered-card-animation-appear centered-card-animation-appear-active"
+    width="28.375rem"
+  >
+    <svg
+      class="c2"
+      color="#001E3E"
+      data-testid="close-icon"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+    Content
+  </div>
+</div>
+`;

--- a/src/components/Offcanvas/components/CenteredCard.tsx
+++ b/src/components/Offcanvas/components/CenteredCard.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { CSSTransition } from 'react-transition-group';
+import styled, { css } from 'styled-components';
+import { Elevation } from '../../../essentials';
+import { Card, CardProps } from '../../Card/Card';
+
+const ANIMATION_DURATION = 150;
+const TRANSITION_KEY = 'centered-card-animation';
+
+const inFrom = {
+    top: css`
+        &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+            opacity: 0;
+            transform: translate(0%, calc(-50% - 1rem));
+        }
+
+        &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
+
+        &.${TRANSITION_KEY}-exit {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
+
+        &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+            opacity: 0;
+            transform: translate(-0%, -50%);
+        }
+    `,
+    bottom: css`
+        &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+            opacity: 0;
+            transform: translate(0%, calc(50% + 1rem));
+        }
+
+        &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
+
+        &.${TRANSITION_KEY}-exit {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
+
+        &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+            opacity: 0;
+            transform: translate(0%, 10%);
+        }
+    `
+};
+
+const position = {
+    top: css`
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: unset;
+    `,
+    bottom: css`
+        left: 0;
+        right: 0;
+        top: unset;
+        bottom: 0;
+    `
+};
+
+const StyledCard = styled(Card)<{ side?: string }>`
+    position: fixed;
+    
+    left: ${p => (p.side === 'right' ? 'unset' : 0)};
+    right: ${p => (p.side === 'right' ? 0 : 'unset')};
+    transform: translate(0%, 0%);
+    z-index: ${Elevation.CARD_ON_DIMMING};
+    width: 100%;
+    will-change: transform, opacity;
+    transition: transform ${ANIMATION_DURATION}ms ease-out, opacity ${ANIMATION_DURATION}ms ease-out;
+
+    ${p => inFrom[p.side]};
+    ${p => position[p.side]};
+
+    @media (max-width: calc(${p => p.width} + 2rem)) {
+        width: calc(100% - 2rem);
+    }
+`;
+
+const CenteredCard: React.FC<CardProps & { visible: boolean; side: string }> = ({
+    visible,
+    height = '28.375rem',
+    ...rest
+}) => {
+    return (
+        <CSSTransition in={visible} classNames={TRANSITION_KEY} timeout={ANIMATION_DURATION} unmountOnExit appear>
+            <StyledCard {...rest} height={height} level={300} />
+        </CSSTransition>
+    );
+};
+
+export { CenteredCard, ANIMATION_DURATION };

--- a/src/components/Offcanvas/components/DimmingFade.tsx
+++ b/src/components/Offcanvas/components/DimmingFade.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { CSSTransition } from 'react-transition-group';
+import styled, { css } from 'styled-components';
+import { Dimming } from '../../Dimming/Dimming';
+import { Colors } from '../../../essentials';
+
+const TRANSITION_KEY = 'dimming-fade-animation';
+const ANIMATION_DURATION = 200;
+
+const fadeInAnimation = (maxOpacity = 0.6) => css`
+    transition: opacity ${ANIMATION_DURATION}ms cubic-bezier(0.215, 0.61, 0.355, 1);
+
+    &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+        opacity: 0;
+    }
+
+    &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+        opacity: ${maxOpacity};
+    }
+
+    &.${TRANSITION_KEY}-exit {
+        opacity: ${maxOpacity};
+    }
+
+    &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+        opacity: 0;
+    }
+`;
+
+const fullscreenDimming = css`
+    background-color: ${Colors.WHITE};
+    opacity: 1;
+`;
+
+const DimmingFadeStyled = styled(Dimming)<{ fullscreen?: boolean }>`
+    will-change: opacity;
+
+    ${p => (p.fullscreen ? fadeInAnimation(1) : fadeInAnimation())};
+    ${p => (p.fullscreen ? fullscreenDimming : null)}
+`;
+
+const DimmingFade: React.FC<{ visible: boolean; fullscreen?: boolean; onClick: () => void }> = ({
+    visible,
+    ...rest
+}) => {
+    return (
+        <CSSTransition in={visible} classNames={TRANSITION_KEY} timeout={ANIMATION_DURATION} unmountOnExit appear>
+            <DimmingFadeStyled {...rest} />
+        </CSSTransition>
+    );
+};
+
+export { DimmingFade, ANIMATION_DURATION };

--- a/src/components/Offcanvas/components/SideCard.tsx
+++ b/src/components/Offcanvas/components/SideCard.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { CSSTransition } from 'react-transition-group';
+import styled, { css } from 'styled-components';
+import { Elevation } from '../../../essentials';
+import { Card, CardProps } from '../../Card/Card';
+
+const ANIMATION_DURATION = 150;
+const TRANSITION_KEY = 'centered-card-animation';
+
+const fromLeft = css`
+    &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+        opacity: 0;
+        transform: translate(calc(-50% - 1rem), 0%);
+    }
+
+    &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+        opacity: 0;
+        transform: translate(-10%, 0%);
+    }
+`;
+
+const fromRight = css`
+    &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+        opacity: 0;
+        transform: translate(calc(50% + 1rem), 0%);
+    }
+
+    &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit {
+        opacity: 1;
+        transform: translate(0%, 0%);
+    }
+
+    &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+        opacity: 0;
+        transform: translate(+10%, 0%);
+    }
+`;
+
+const right = css`
+    left: unset;
+    right: 0;
+    top: 0;
+    bottom: 0;
+`;
+
+const left = css`
+    left: 0;
+    right: unset;
+    top: 0;
+    bottom: 0;
+`;
+
+const StyledCard = styled(Card)<{ side?: string }>`
+    position: fixed;
+    
+    left: ${p => (p.side === 'right' ? 'unset' : 0)};
+    right: ${p => (p.side === 'right' ? 0 : 'unset')};
+    transform: translate(0%, 0%);
+    z-index: ${Elevation.CARD_ON_DIMMING};
+    height: 100%;
+    will-change: transform, opacity;
+    transition: transform ${ANIMATION_DURATION}ms ease-out, opacity ${ANIMATION_DURATION}ms ease-out;
+
+    ${p => (p.side === 'right' ? fromRight : fromLeft)};
+    ${p => (p.side === 'right' ? right : left)};
+
+    @media (max-width: calc(${p => p.width} + 2rem)) {
+        width: calc(100% - 2rem);
+    }
+`;
+
+const SideCard: React.FC<CardProps & { visible: boolean; side: string }> = ({
+    visible,
+    width = '28.375rem',
+    ...rest
+}) => {
+    return (
+        <CSSTransition in={visible} classNames={TRANSITION_KEY} timeout={ANIMATION_DURATION} unmountOnExit appear>
+            <StyledCard {...rest} width={width} level={300} />
+        </CSSTransition>
+    );
+};
+
+export { SideCard, ANIMATION_DURATION };

--- a/src/components/Offcanvas/components/SideCard.tsx
+++ b/src/components/Offcanvas/components/SideCard.tsx
@@ -7,63 +7,65 @@ import { Card, CardProps } from '../../Card/Card';
 const ANIMATION_DURATION = 150;
 const TRANSITION_KEY = 'centered-card-animation';
 
-const fromLeft = css`
-    &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
-        opacity: 0;
-        transform: translate(calc(-50% - 1rem), 0%);
-    }
+const inFrom = {
+    right: css`
+        &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+            opacity: 0;
+            transform: translate(calc(50% + 1rem), 0%);
+        }
 
-    &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
-        opacity: 1;
-        transform: translate(0%, 0%);
-    }
+        &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
 
-    &.${TRANSITION_KEY}-exit {
-        opacity: 1;
-        transform: translate(0%, 0%);
-    }
+        &.${TRANSITION_KEY}-exit {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
 
-    &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
-        opacity: 0;
-        transform: translate(-10%, 0%);
-    }
-`;
+        &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+            opacity: 0;
+            transform: translate(+10%, 0%);
+        }
+    `,
+    left: css`
+        &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
+            opacity: 0;
+            transform: translate(calc(-50% - 1rem), 0%);
+        }
 
-const fromRight = css`
-    &.${TRANSITION_KEY}-appear, &.${TRANSITION_KEY}-enter {
-        opacity: 0;
-        transform: translate(calc(50% + 1rem), 0%);
-    }
+        &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
 
-    &.${TRANSITION_KEY}-appear-active, &.${TRANSITION_KEY}-enter-active {
-        opacity: 1;
-        transform: translate(0%, 0%);
-    }
+        &.${TRANSITION_KEY}-exit {
+            opacity: 1;
+            transform: translate(0%, 0%);
+        }
 
-    &.${TRANSITION_KEY}-exit {
-        opacity: 1;
-        transform: translate(0%, 0%);
-    }
+        &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
+            opacity: 0;
+            transform: translate(-10%, 0%);
+        }
+    `
+};
 
-    &.${TRANSITION_KEY}-exit-done, &.${TRANSITION_KEY}-exit-active {
-        opacity: 0;
-        transform: translate(+10%, 0%);
-    }
-`;
-
-const right = css`
-    left: unset;
-    right: 0;
-    top: 0;
-    bottom: 0;
-`;
-
-const left = css`
-    left: 0;
-    right: unset;
-    top: 0;
-    bottom: 0;
-`;
+const position = {
+    right: css`
+        left: unset;
+        right: 0;
+        top: 0;
+        bottom: 0;
+    `,
+    left: css`
+        left: 0;
+        right: unset;
+        top: 0;
+        bottom: 0;
+    `
+};
 
 const StyledCard = styled(Card)<{ side?: string }>`
     position: fixed;
@@ -76,8 +78,8 @@ const StyledCard = styled(Card)<{ side?: string }>`
     will-change: transform, opacity;
     transition: transform ${ANIMATION_DURATION}ms ease-out, opacity ${ANIMATION_DURATION}ms ease-out;
 
-    ${p => (p.side === 'right' ? fromRight : fromLeft)};
-    ${p => (p.side === 'right' ? right : left)};
+    ${p => inFrom[p.side]};
+    ${p => position[p.side]};
 
     @media (max-width: calc(${p => p.width} + 2rem)) {
         width: calc(100% - 2rem);

--- a/src/components/Offcanvas/components/TopRightXIcon.tsx
+++ b/src/components/Offcanvas/components/TopRightXIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Elevation, Spaces } from '../../../essentials';
+import { CloseIcon } from '../../../icons';
+
+const TopRightXIcon = styled(CloseIcon)`
+    position: absolute;
+    top: ${Spaces[1]};
+    right: ${Spaces[1]};
+    cursor: pointer;
+    z-index: ${Elevation.CARD_ON_DIMMING};
+`;
+
+export { TopRightXIcon };

--- a/src/components/Offcanvas/docs/Offcanvas.mdx
+++ b/src/components/Offcanvas/docs/Offcanvas.mdx
@@ -1,0 +1,79 @@
+---
+name: Offcanvas
+menu: Components
+route: /components/Offcanvas
+---
+
+import { Offcanvas } from '../Offcanvas.tsx';
+import { OffcanvasCreator } from './OffcanvasCreator.tsx';
+import { OffcanvasPropsTable } from './OffcanvasPropsTable.tsx';
+import { StyledSystemLinks } from '../../../docs/StyledSystemLinks'
+
+# Offcanvas
+
+The Offcanvas should only contain content or flows which are related to the current page and not replace pages, therefore
+its complexity level has to be simple. Consider the fullscreen state if you want to focus the users attention to the Offcanvas
+content.
+
+Offcanvas is responsive per default but the width can be adjusted (the default is 600px or 37.5rem). Content on the Offcanvas
+is scrollable and has a space5 bounding box.
+
+<OffcanvasCreator />
+
+### Example Code
+
+The following contains a simple example, with a resulting Offcanvas similar to the live examples above.
+
+```jsx
+const [showOffcanvas, setShowOffcanvas] = useState(true);
+
+<Offcanvas onClose={() => setShowOffcanvas(false)} fullscreen={true}>
+    {dismiss => (
+        <>
+            <Headline as="h2">Add Note</Headline>
+            <Text as="p" my={3}>
+                Ensure that all participants are aware of the change.
+            </Text>
+            <Button onClick={dismiss}>Add Note</Button>
+            <TextButton onClick={dismiss}>Cancel</TextButton>
+        </>
+    )}
+</Offcanvas>;
+```
+
+## API
+
+<OffcanvasPropsTable />
+
+<br />
+
+<StyledSystemLinks component="Offcanvas" supportedProps={ ['width'] }/>
+
+### Dismiss
+
+Offcanvas provides a function to dismiss the component with an animation. The
+dismiss function is available either through render props or a hook. After the
+animation has finished the `onClose` callback will be called.
+
+#### Render Props
+
+```jsx
+<Offcanvas>
+    {dismiss => <Button onClick={dismiss}>Close</Button>}
+</Offcanvas>
+```
+
+#### Hook
+
+```jsx
+const InsideOffcanvas = () => {
+    const dismiss = useOffcanvasDismiss();
+    return <button onClick={dismiss}>Close</button>;
+}
+
+const OffcanvasWrapper = () => (
+    <Offcanvas>
+        <InsideOffcanvas />
+    </Offcanvas>
+);
+```

--- a/src/components/Offcanvas/docs/OffcanvasCreator.tsx
+++ b/src/components/Offcanvas/docs/OffcanvasCreator.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { Button, Headline, Text, TextButton } from '../..';
+import { Offcanvas } from '../Offcanvas';
+
+const offcanvasContent = dismiss => (
+    <>
+        <Headline as="h2">Add Note</Headline>
+        <Text as="p" weak my={3}>
+            Please keep in mind that comments are also read by other agents. Make sure to write comprehensible text.
+        </Text>
+        <Button onClick={dismiss}>Add Note</Button>
+        <TextButton ml={1} onClick={dismiss}>
+            Cancel
+        </TextButton>
+    </>
+);
+
+enum OffcanvasType {
+    NONE,
+    DEFAULT,
+    LEFT,
+    RIGHT,
+    NON_DISMISSIBLE
+}
+
+const OffcanvasCreator = () => {
+    const [offcanvas, setOffcanvas] = useState(OffcanvasType.NONE);
+
+    const openOffcanvas = (type: OffcanvasType) => () => {
+        setOffcanvas(type);
+    };
+
+    const hideOffcanvas = () => {
+        setOffcanvas(OffcanvasType.NONE);
+    };
+
+    return (
+        <>
+            <Button size="small" mr={1} onClick={openOffcanvas(OffcanvasType.DEFAULT)}>
+                Default (Left) Offcanvas
+            </Button>
+            <Button size="small" mr={1} onClick={openOffcanvas(OffcanvasType.RIGHT)}>
+                Right Offcanvas
+            </Button>
+            <Button size="small" onClick={openOffcanvas(OffcanvasType.NON_DISMISSIBLE)}>
+                Non-Dismissible Offcanvas
+            </Button>
+
+            {offcanvas == OffcanvasType.DEFAULT && (
+                <Offcanvas side="left" onClose={hideOffcanvas}>
+                    {offcanvasContent}
+                </Offcanvas>
+            )}
+            {offcanvas == OffcanvasType.RIGHT && (
+                <Offcanvas side="right" onClose={hideOffcanvas}>
+                    {offcanvasContent}
+                </Offcanvas>
+            )}
+            {offcanvas == OffcanvasType.NON_DISMISSIBLE && (
+                <Offcanvas onClose={hideOffcanvas} dismissible={false}>
+                    {offcanvasContent}
+                </Offcanvas>
+            )}
+        </>
+    );
+};
+
+export { OffcanvasCreator };

--- a/src/components/Offcanvas/docs/OffcanvasCreator.tsx
+++ b/src/components/Offcanvas/docs/OffcanvasCreator.tsx
@@ -20,6 +20,8 @@ enum OffcanvasType {
     DEFAULT,
     LEFT,
     RIGHT,
+    TOP,
+    BOTTOM,
     NON_DISMISSIBLE
 }
 
@@ -42,6 +44,12 @@ const OffcanvasCreator = () => {
             <Button size="small" mr={1} onClick={openOffcanvas(OffcanvasType.RIGHT)}>
                 Right Offcanvas
             </Button>
+            <Button size="small" mr={1} onClick={openOffcanvas(OffcanvasType.TOP)}>
+                Top Offcanvas
+            </Button>
+            <Button size="small" mr={1} onClick={openOffcanvas(OffcanvasType.BOTTOM)}>
+                Bottom Offcanvas
+            </Button>
             <Button size="small" onClick={openOffcanvas(OffcanvasType.NON_DISMISSIBLE)}>
                 Non-Dismissible Offcanvas
             </Button>
@@ -53,6 +61,16 @@ const OffcanvasCreator = () => {
             )}
             {offcanvas == OffcanvasType.RIGHT && (
                 <Offcanvas side="right" onClose={hideOffcanvas}>
+                    {offcanvasContent}
+                </Offcanvas>
+            )}
+            {offcanvas == OffcanvasType.TOP && (
+                <Offcanvas side="top" onClose={hideOffcanvas}>
+                    {offcanvasContent}
+                </Offcanvas>
+            )}
+            {offcanvas == OffcanvasType.BOTTOM && (
+                <Offcanvas side="bottom" onClose={hideOffcanvas}>
                     {offcanvasContent}
                 </Offcanvas>
             )}

--- a/src/components/Offcanvas/docs/OffcanvasPropsTable.tsx
+++ b/src/components/Offcanvas/docs/OffcanvasPropsTable.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { PropsTable } from '../../../docs/PropsTable';
+
+export const OffcanvasPropsTable = () => {
+    const props = [
+        {
+            name: 'side',
+            type: '"left" | "right"',
+            description: 'Show the Offcanvas on the side of the page: left or right.',
+            defaultValue: '-'
+        },
+        {
+            name: 'dismissible',
+            type: 'boolean',
+            description: 'Makes the Offcanvas dismissible by the user.',
+            defaultValue: 'true'
+        },
+        {
+            name: 'onClose',
+            type: '() => void',
+            description:
+                'A function that will be called after the user has dismissed the Offcanvas and the Offcanvas has disappeared.',
+            defaultValue: '-'
+        }
+    ];
+    return <PropsTable props={props} />;
+};


### PR DESCRIPTION
**What:**
Add `Offcanvas` component
​
**Why:**
We need an `Offcanvas` for this [design](https://app.zeplin.io/project/57fe438f81b870887cc71736/screen/60900157d95163088c092d08).
​
**How:**
Add a new component `Offcanvas` which follows the same logic of the `Modal`. 
It receives the side props ("left" | "right" | "top" | "bottom") and slides in from the relative side.
​
**Media:**
<img width="842" alt="Screenshot 2021-06-10 at 17 57 10" src="https://user-images.githubusercontent.com/12762609/121557737-4a068f80-ca15-11eb-868d-3938d608bd39.png">


See more in this video on [loom](https://www.loom.com/share/eed122adea8a4c539981bfe6557a6e68)

**Checklist:**

- [x] Ready to be merged

See this [pull-request](https://github.com/freenowtech/wave/pull/114) thread for more info. 
