### PR TITLE
fix(checkbox): remove outline: none;

### DIFF
--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Checkbox renders large checkbox 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -152,7 +152,7 @@ exports[`Checkbox renders medium checkbox 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -299,7 +299,7 @@ exports[`Checkbox renders small checkbox 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -446,7 +446,7 @@ exports[`Checkbox renders the checked style 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -594,7 +594,7 @@ exports[`Checkbox renders the disabled checked style 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -739,7 +739,7 @@ exports[`Checkbox renders the disabled style 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -883,7 +883,7 @@ exports[`Checkbox renders the error checked style 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -1027,7 +1027,7 @@ exports[`Checkbox renders the error style 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;
@@ -1174,7 +1174,7 @@ exports[`Checkbox renders with default props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  outline: none;
+  outline-offset: 0.25rem;
   border: none;
   position: relative;
   width: 1rem;

--- a/src/components/Checkbox/components/Checkmark.tsx
+++ b/src/components/Checkbox/components/Checkmark.tsx
@@ -8,7 +8,7 @@ interface CheckmarkProps {
 
 const Checkmark = styled.input<CheckmarkProps>`
     appearance: none;
-    outline: none;
+    outline-offset: 0.25rem;
     border: none;
 
     position: relative;


### PR DESCRIPTION
**What:**
Improve keyboard a11y of checkbox 
​
**Why:**
Closes #23 
​
**How:**
Remove the outline "none" and keep built-in one
​
**Media:**
![CleanShot 2021-06-11 at 15 46 09](https://user-images.githubusercontent.com/1425162/121696497-6ca7af80-cacc-11eb-85ef-9961c0360001.png)

**Checklist:**
- [x] Ready to be merged
