### PR TITLE
Adds skip to content link to the Wave Web

### DIFF
--- a/src/gatsby-theme-docz/components/Header/index.js
+++ b/src/gatsby-theme-docz/components/Header/index.js
@@ -34,6 +34,18 @@ const LogoLink = styled(Link)`
     }
 `;
 
+const SkipLink = styled.a`
+    color: white;
+    position: absolute;
+    padding: 0.5rem;
+    transform: translateY(-100%);
+
+    &:focus {
+        transition: 0.216s transform;
+        transform: translateY(0%);
+    }
+`;
+
 export const Header = ({ onOpen: onMenuOpen }) => {
     return (
         <>
@@ -47,6 +59,7 @@ export const Header = ({ onOpen: onMenuOpen }) => {
                 <LogoLink aria-label="go to home screen" to="/">
                     <WaveLogoAnimated />
                 </LogoLink>
+                <SkipLink href="#main">Skip to content</SkipLink>
                 <MenuButton onClick={onMenuOpen} />
             </HeaderWrapper>
         </>

--- a/src/gatsby-theme-docz/components/Layout/index.js
+++ b/src/gatsby-theme-docz/components/Layout/index.js
@@ -44,7 +44,9 @@ export const Layout = ({ children }) => {
                         onBlur={() => setOpen(false)}
                         onClick={() => setOpen(false)}
                     />
-                    <MainContainer data-testid="main-container">{children}</MainContainer>
+                    <MainContainer id="main" data-testid="main-container">
+                        {children}
+                    </MainContainer>
                 </LayoutContainer>
             </MainBox>
         </div>

--- a/src/gatsby-theme-docz/components/MainContainer/index.js
+++ b/src/gatsby-theme-docz/components/MainContainer/index.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const MainContainer = styled.div`
+export const MainContainer = styled.main`
     position: relative;
     padding: 1.5rem;
     max-width: initial;


### PR DESCRIPTION
**What:**
Improve content keyboard accessibility
​
**Why:**
We don't want to tab through the whole list of components to react the content

**How:**
Add [skip link](https://webaim.org/techniques/skipnav) to the header of the documentation page

To reach the skip link, use the Tab key on the keyboard.
​
**Media:**
https://www.loom.com/share/4172315357eb4b84a42b3fb818e37386

**Checklist:**

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
