### PR TITLE
improvement: making input ids passable by props for datepicker

### DIFF
--- a/src/components/Datepicker/DatepickerRangeInput.tsx
+++ b/src/components/Datepicker/DatepickerRangeInput.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system';
 import { Colors, Elevation, MediaQueries } from '../../essentials';
 import { theme } from '../../essentials/theme';
+import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 import { ChevronRightIcon } from '../../icons';
 import { Input } from '../Input/Input';
 
@@ -153,6 +154,14 @@ interface DatepickerRangeInputProps extends MarginProps, WidthProps {
      * or fn to be trigger as a callback when error
      */
     errorHandler?: (() => void) | string;
+    /**
+     * The id to be assigned to the start date input
+     */
+    startInputId?: string;
+    /**
+     * The id to be assigned to the end date input
+     */
+    endInputId?: string;
 }
 
 interface DateRangeInputText {
@@ -199,6 +208,8 @@ const DatepickerRangeInput = ({
     locale = 'en-US',
     value = {},
     errorHandler,
+    startInputId,
+    endInputId,
     ...rest
 }: DatepickerRangeInputProps) => {
     const localeObject = useLocaleObject(locale);
@@ -210,6 +221,9 @@ const DatepickerRangeInput = ({
     );
     const [error, setError] = useState({ startDate: false, endDate: false });
     const displayErrorMessage = typeof errorHandler === 'string';
+
+    const startId = useGeneratedId(startInputId);
+    const endId = useGeneratedId(endInputId);
 
     useEffect(() => {
         if (!focusedInput && (error.startDate || error.endDate) && typeof errorHandler === 'function') {
@@ -312,6 +326,7 @@ const DatepickerRangeInput = ({
                 <>
                     <DateRangeWrapper ref={ref} {...rest}>
                         <Input
+                            id={startId}
                             ref={startDateRef}
                             autoComplete="off"
                             className="startDate"
@@ -328,6 +343,7 @@ const DatepickerRangeInput = ({
                         {focusedInput === START_DATE && <StartDateFocusedBlock />}
                         <DateArrow color={Colors.AUTHENTIC_BLUE_550} />
                         <Input
+                            id={endId}
                             ref={endDateRef}
                             tabIndex={!inputText.startText ? -1 : 0}
                             autoComplete="off"

--- a/src/components/Datepicker/DatepickerSingleInput.tsx
+++ b/src/components/Datepicker/DatepickerSingleInput.tsx
@@ -8,6 +8,7 @@ import { Input } from '../Input/Input';
 import { Datepicker } from './Datepicker';
 import { isValidDateText } from './utils/isValidDateText';
 import { Elevation } from '../../essentials';
+import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 import { HelperText } from '../HelperText/HelperText';
 import { dateToDisplayText } from './utils/dateToDisplayText';
 import { useLocaleObject } from './utils/useLocaleObject';
@@ -66,6 +67,10 @@ interface DatepickerSingleInputProps extends MarginProps, WidthProps {
      * or fn to be trigger as a callback when error
      */
     errorHandler?: (() => void) | string;
+    /**
+     * The id to be assigned to the input field
+     */
+    inputId?: string;
 }
 
 const DatepickerSingleInput = ({
@@ -81,6 +86,7 @@ const DatepickerSingleInput = ({
     locale = 'en-US',
     value,
     errorHandler,
+    inputId,
     ...rest
 }: DatepickerSingleInputProps) => {
     const localeObject = useLocaleObject(locale);
@@ -89,6 +95,8 @@ const DatepickerSingleInput = ({
     const [inputText, setInputText] = useState(dateToDisplayText(localeObject, displayFormat, value));
     const [error, setError] = useState(false);
     const displayErrorMessage = typeof errorHandler === 'string';
+
+    const id = useGeneratedId(inputId);
 
     useEffect(() => {
         if (error && typeof errorHandler === 'function') {
@@ -155,6 +163,7 @@ const DatepickerSingleInput = ({
                                 inputRef.current = element;
                                 ref.current = element;
                             }}
+                            id={id}
                             autoComplete="off"
                             className="startDate"
                             data-testid="start-date-input"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:** This PR intends to enable passing of the `inputId` as props for the `DatePicker` component
<!-- Declarative and short sentence of what this PR accomplish -->
​
**Why:** This is to give the end user more control over the form elements
<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
​

**Media:** Nothing to see here
<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
