### PR TITLE
feat: add new label variants and filled prop

### DIFF
--- a/src/components/Label/Label.spec.tsx
+++ b/src/components/Label/Label.spec.tsx
@@ -20,6 +20,14 @@ describe('Label', () => {
         `);
     });
 
+    it('has the correct info variant colors', () => {
+        expect(render(<Label variant="info" />).container.firstChild).toHaveStyle(`
+            color: ${Colors.ACTION_BLUE_900};
+            border-color: ${Colors.ACTION_BLUE_350};
+            background-color: ${Colors.ACTION_BLUE_50};
+        `);
+    });
+
     it('has the correct success variant colors', () => {
         expect(render(<Label variant="success" />).container.firstChild).toHaveStyle(`
             color: ${Colors.POSITIVE_GREEN_1000};
@@ -33,6 +41,14 @@ describe('Label', () => {
             color: ${Colors.NEGATIVE_ORANGE_1000};
             border-color: ${Colors.NEGATIVE_ORANGE_350};
             background-color: ${Colors.NEGATIVE_ORANGE_50};
+        `);
+    });
+
+    it('uses the filled version if set', () => {
+        expect(render(<Label variant="success" filled />).container.firstChild).toHaveStyle(`
+            color: ${Colors.WHITE};
+            border-color: ${Colors.POSITIVE_GREEN_900};
+            backgroundColor: ${Colors.POSITIVE_GREEN_900};
         `);
     });
 });

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -8,27 +8,72 @@ import { get } from '../../utils/themeGet';
 
 interface LabelProps extends MarginProps {
     /**
-     * Set the appropriate colors for the component with 'info' as a default
+     * Set the appropriate colors for the component with 'default' as a default
      */
-    variant?: ResponsiveValue<'info' | 'success' | 'danger'>;
+    variant?: ResponsiveValue<'default' | 'info' | 'success' | 'warning' | 'danger'>;
+
+    /**
+     * Use the alternative version of the label for critical status and extra emphasis
+     */
+    filled?: boolean;
 }
 
-const variantStyles = variant({
+const normalVariantStyles = variant({
     variants: {
-        info: {
+        default: {
             color: Colors.AUTHENTIC_BLUE_900,
             borderColor: Colors.AUTHENTIC_BLUE_200,
             backgroundColor: Colors.AUTHENTIC_BLUE_50
+        },
+        info: {
+            color: Colors.ACTION_BLUE_900,
+            borderColor: Colors.ACTION_BLUE_350,
+            backgroundColor: Colors.ACTION_BLUE_50
         },
         success: {
             color: Colors.POSITIVE_GREEN_1000,
             borderColor: Colors.POSITIVE_GREEN_350,
             backgroundColor: Colors.POSITIVE_GREEN_50
         },
+        warning: {
+            color: Colors.AUTHENTIC_BLUE_900,
+            borderColor: Colors.ATTENTION_YELLOW_350,
+            backgroundColor: Colors.ATTENTION_YELLOW_50
+        },
         danger: {
             color: Colors.NEGATIVE_ORANGE_1000,
             borderColor: Colors.NEGATIVE_ORANGE_350,
             backgroundColor: Colors.NEGATIVE_ORANGE_50
+        }
+    }
+});
+
+const filledVariantStyles = variant({
+    variants: {
+        default: {
+            color: Colors.WHITE,
+            borderColor: Colors.AUTHENTIC_BLUE_350,
+            backgroundColor: Colors.AUTHENTIC_BLUE_350
+        },
+        info: {
+            color: Colors.WHITE,
+            borderColor: Colors.ACTION_BLUE_900,
+            backgroundColor: Colors.ACTION_BLUE_900
+        },
+        success: {
+            color: Colors.WHITE,
+            borderColor: Colors.POSITIVE_GREEN_900,
+            backgroundColor: Colors.POSITIVE_GREEN_900
+        },
+        warning: {
+            color: Colors.AUTHENTIC_BLUE_900,
+            borderColor: Colors.ATTENTION_YELLOW_900,
+            backgroundColor: Colors.ATTENTION_YELLOW_900
+        },
+        danger: {
+            color: Colors.WHITE,
+            borderColor: Colors.NEGATIVE_ORANGE_900,
+            backgroundColor: Colors.NEGATIVE_ORANGE_900
         }
     }
 });
@@ -41,11 +86,14 @@ const Label: FC<LabelProps> = styled(Text).attrs({ theme })<LabelProps>`
     font-weight: ${get('fontWeights.semibold')};
     padding: 0.1875rem 0.5rem;
 
-    color: ${Colors.AUTHENTIC_BLUE_900};
-    border: 0.0625rem solid ${Colors.AUTHENTIC_BLUE_200};
-    background-color: ${Colors.AUTHENTIC_BLUE_50};
+    border-width: 0.0625rem;
+    border-style: solid;
 
-    ${compose(variantStyles, margin)}
+    ${props => compose(props.filled ? filledVariantStyles : normalVariantStyles, margin)(props)}
 `;
+
+Label.defaultProps = {
+    variant: 'default'
+};
 
 export { Label, LabelProps };

--- a/src/components/Label/docs/Label.mdx
+++ b/src/components/Label/docs/Label.mdx
@@ -25,12 +25,15 @@ Use short labels for easy scanning. Use two words only if necessary to describe 
 ## Examples
 
 <Playground>
-    <Label variant="success">Label</Label>
+    <Label mr={1}>Default</Label>
+    <Label variant="success" filled mr={1}>Congratulations</Label>
+    <Label variant="warning" mr={1}>Caution</Label>
+    <Label variant="danger" filled mr={1}>Failed️</Label>
 </Playground>
 
 ## Combinations
 
-<Combination variant={["info", "success", "danger"]}>
+<Combination variant={["default", "info", "success", "warning", "danger"]} filled={[false, true]}>
     {(props, i) => <Label key={i} {...props}>Label</Label>}
 </Combination>
 

--- a/src/components/Label/docs/LabelPropsTable.tsx
+++ b/src/components/Label/docs/LabelPropsTable.tsx
@@ -5,9 +5,14 @@ export const LabelPropsTable = () => {
     const props = [
         {
             name: 'variant',
-            type: '"info" | "success" | "danger"',
+            type: '"default" | "info" | "success" | "warning" | "danger"',
             description: 'Set the appropriate colors for the component',
-            defaultValue: '"info"'
+            defaultValue: '"default"'
+        },
+        {
+            name: 'filled',
+            type: 'boolean',
+            description: 'Adds additional emphasis or highlight critical status'
         }
     ];
     return <PropsTable props={props} />;


### PR DESCRIPTION
**What:**
Adding new label color "info" and "warning" in addition to the ability to give all labels a more prominent style with the "filled" prop. Closes #2 .
​
**Why:**
Some of the recent designs include additional label styles that are used in tables across our tools. Currently they are Label components with custom styles. To provide a common and reusable pattern, we want to include these styles in the library.
​​
**Media:**
<img width="855" alt="image" src="https://user-images.githubusercontent.com/8927747/123098603-97c9c180-d431-11eb-8be5-31ab0da12be1.png">

**Checklist:**
- [ ] Ready to be merged

**Other:**
This will change the styling of the variant "info" from grey to blue, while introducing a new variant (default) to replace the grey styles. The change can lead to unexpected colours of the label when the variant is explicitly specified. It will not cause any issue when no variant is specified, as the default looks identical.