### PR TITLE
improvement: adding aria-label to items rendered by TableRowSkeleton

### DIFF
--- a/src/components/Table/components/TableRowSkeleton.spec.tsx
+++ b/src/components/Table/components/TableRowSkeleton.spec.tsx
@@ -15,6 +15,22 @@ describe('TableRowSkeleton', () => {
         );
 
         expect(screen.getAllByRole('cell').length).toBe(columns);
-        expect(screen.getAllByLabelText('table-row-skeleton').length).toBe(columns);
+    });
+
+    it('should contain the correct hidden label text', () => {
+        const columns = 3;
+
+        render(
+            <table>
+                <tbody>
+                    <TableRowSkeleton columns={columns} />
+                </tbody>
+            </table>
+        );
+        const elements = screen.getAllByLabelText('table-row-skeleton');
+        expect(elements.length).toBe(columns);
+        elements.forEach(element => {
+            expect(element.attributes.getNamedItem('aria-hidden')).toBeTruthy();
+        });
     });
 });

--- a/src/components/Table/components/TableRowSkeleton.spec.tsx
+++ b/src/components/Table/components/TableRowSkeleton.spec.tsx
@@ -15,5 +15,6 @@ describe('TableRowSkeleton', () => {
         );
 
         expect(screen.getAllByRole('cell').length).toBe(columns);
+        expect(screen.getAllByLabelText('table-row-skeleton').length).toBe(columns);
     });
 });

--- a/src/components/Table/components/TableRowSkeleton.tsx
+++ b/src/components/Table/components/TableRowSkeleton.tsx
@@ -15,7 +15,7 @@ export const TableRowSkeleton = ({ columns, animated }: TableRowSkeletonProps) =
                 .fill(0)
                 .map((_, index) => (
                     <TableCell key={index}>
-                        <Skeleton animated={animated} />
+                        <Skeleton aria-label="table-row-skeleton" aria-hidden animated={animated} />
                     </TableCell>
                 ))}
         </TableRow>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:** This PR adds an `aria-label` property to elements rendered by `TableRowSkeleton` to enable accessibility testing
<!-- Declarative and short sentence of what this PR accomplish -->
​
**Why:** This addresses issue #80 
<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
​
**How:**
<!-- Often a list of things to describe the process to accomplish this PR -->
​1. Add an `aria-label` property to `Skeleton` elements rendered by `TableRowSkeleton`
2. Set `aria-hidden` to `true` as this is not something you want screen readers to pick up
3. Update tests.
**Media:** Nothing to see here
<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
