### PR TITLE
improvement: adding a prop called variant for datepicker range

### DIFF
--- a/src/components/Datepicker/DatepickerRangeInput.tsx
+++ b/src/components/Datepicker/DatepickerRangeInput.tsx
@@ -162,6 +162,12 @@ interface DatepickerRangeInputProps extends MarginProps, WidthProps {
      * The id to be assigned to the end date input
      */
     endInputId?: string;
+    /**
+     * Determines the variant
+     * @value `'compact'` displays only a single month
+     * @default 'normal'
+     */
+    variant?: 'compact' | 'normal';
 }
 
 interface DateRangeInputText {
@@ -210,6 +216,7 @@ const DatepickerRangeInput = ({
     errorHandler,
     startInputId,
     endInputId,
+    variant = 'normal',
     ...rest
 }: DatepickerRangeInputProps) => {
     const localeObject = useLocaleObject(locale);
@@ -369,7 +376,7 @@ const DatepickerRangeInput = ({
                     <Datepicker
                         ref={ref}
                         // TODO: refer to https://stash.intapps.it/projects/DS/repos/wave/pull-requests/104/overview?commentId=168382
-                        numberOfMonths={window.innerWidth >= 768 ? 2 : 1}
+                        numberOfMonths={variant === 'normal' && window.innerWidth >= 768 ? 2 : 1}
                         minBookingDays={1}
                         startDate={value.startDate || null}
                         endDate={value.endDate || null}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:** This PR intends to add a `variant` property to the datepicker
<!-- Declarative and short sentence of what this PR accomplish -->
​
**Why:** This is introduced to enable developers to decide whether to show only a single month or two months, according to their needs, without breaking the current responsive behavior.
<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
​
**How:**
1. Create a prop `variant`
<!-- Often a list of things to describe the process to accomplish this PR -->
​
**Media:** https://www.loom.com/share/9cf8700746d14419a0c4610face30006
<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
