### PR TITLE
Fixes the spelling of the css property in the test

### DIFF
--- a/src/components/Label/Label.spec.tsx
+++ b/src/components/Label/Label.spec.tsx
@@ -48,7 +48,7 @@ describe('Label', () => {
         expect(render(<Label variant="success" filled />).container.firstChild).toHaveStyle(`
             color: ${Colors.WHITE};
             border-color: ${Colors.POSITIVE_GREEN_900};
-            backgroundColor: ${Colors.POSITIVE_GREEN_900};
+            background-color: ${Colors.POSITIVE_GREEN_900};
         `);
     });
 });


### PR DESCRIPTION
Since the PR #125 was merged a little bit prematurely, I haven't had a chance to address the code review comments. This fixes the wrong spelling of the css property when testing for a specific Label version.