### PR TITLE
Add the crypto api polyfill for IE 11

### DIFF
--- a/docs/browser-support.mdx
+++ b/docs/browser-support.mdx
@@ -7,8 +7,7 @@ cardSubHeadline: Creating a consistent experience across browsers and devices.
 
 ## Supported Devices
 
-The design system should be universally accessible, which means that the components should work in the browsers and devices used to access
-the project, which is using the design system. Components might not look perfect in all scenarios, but everything should still be
-accessible to the user.
+The design system should be universally accessible. Components might not look perfect in all scenarios, but everything
+should still be accessible to the user.
 
 **Currently, we are supporting the latest 2 versions of Chrome, Firefox, Safari, Edge and Internet Explorer 11.**

--- a/docs/browser-support.mdx
+++ b/docs/browser-support.mdx
@@ -1,0 +1,14 @@
+---
+name: Browser support
+route: /browser-support
+cardHeadline: Browser support
+cardSubHeadline: Creating a consistent experience across browsers and devices.
+---
+
+## Supported Devices
+
+The design system should be universally accessible, which means that the components should work in the browsers and devices used to access
+the project, which is using the design system. Components might not look perfect in all scenarios, but everything should still be
+accessible to the user.
+
+**Currently, we are supporting the latest 2 versions of Chrome, Firefox, Safari, Edge and Internet Explorer 11.**

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
     title: `Wave`,
-    menu: ['Get Started', 'Changelog', 'Accessibility', 'Contributing', 'Essentials', 'Components'],
+    menu: ['Get Started', 'Changelog', 'Accessibility', 'Browser support', 'Contributing', 'Essentials', 'Components'],
     ignore: ['CONTRIBUTING.md', 'README.md', 'SECURITY.md', 'MAINTAINERS.md', 'fixtures/**/*.md', '.idea/**/*'],
     propsParser: false,
     typescript: true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "typings": "lib/types/index.d.ts",
     "module": "lib/esm/index.js",
     "sideEffects": [
-        "src/polyfills.ts"
+        "lib/esm/polyfills.js",
+        "lib/cjs/polyfills.js"
     ],
     "scripts": {
         "clean": "rm -rf lib",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "main": "lib/cjs/index.js",
     "typings": "lib/types/index.d.ts",
     "module": "lib/esm/index.js",
-    "sideEffects": false,
+    "sideEffects": [
+        "src/polyfills.ts"
+    ],
     "scripts": {
         "clean": "rm -rf lib",
         "build": "npm run clean && npm run build:cjs && npm run build:esm",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './polyfills';
+
 export * from './components';
 export * from './essentials';
 export * from './icons';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,5 +1,9 @@
-// create an alias for the crypto api for IE11
-if (!window.crypto) {
-    // @ts-ignore
-    window.crypto = window.msCrypto;
+import { isSSR } from './utils/isSSR';
+
+if (!isSSR()) {
+    // create an alias for the crypto api for IE11
+    if (!window.crypto) {
+        // @ts-ignore
+        window.crypto = window.msCrypto;
+    }
 }

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,5 @@
+// create an alias for the crypto api for IE11
+if (!window.crypto) {
+    // @ts-ignore
+    window.crypto = window.msCrypto;
+}

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,7 +1,7 @@
 import { isSSR } from './utils/isSSR';
 
 if (!isSSR()) {
-    // create an alias for the crypto api for IE11
+    // create an alias for the crypto api for IE11 (required by `nanoid`)
     if (!window.crypto) {
         // @ts-ignore
         window.crypto = window.msCrypto;


### PR DESCRIPTION
**What:**
Adding a polyfill for IE11 and the Crypto api, closing #131.
​
**Why:**
After introducing the automatically generated ids for Input components using `nanoid`, we noticed a sharp increase of errors in our project. With some investigation, we found that nanoid requires the crypto api to be available on `window.crypto` (https://github.com/ai/nanoid#ie).
​
**How:**
Adding a specific `polyfill.ts` file to include this change to make IE 11 work with the design system again without throwing errors.