### PR TITLE
ci: add release config for next branch

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    branches: ['main'],
+    branches: ['main', 'next'],
     plugins: [
         [
             '@semantic-release/commit-analyzer',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

This PR adds `next` to the list of branches for semantic release.
​
**Why:**

In order to prepare the next major version we want to release automated preview versions. Therefore we can create a `next` branch which should be in sync with `main`. Breaking changes should be done only in `next` branch. When we made all the changes (TBD) for v2 then we can merge `next` back to `main`.
​
**How:**

Add `next` to the semantic release branches.

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
