### PR TITLE
feat: remove the deprecated block property for buttons

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -29,7 +29,7 @@ jobs:
               run: npm run test
 
     release:
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/codemods/v2.ts
+++ b/codemods/v2.ts
@@ -1,0 +1,68 @@
+import { API, Collection, FileInfo, JSCodeshift } from 'jscodeshift';
+
+function transformBlockProperty(j: JSCodeshift, ast: Collection) {
+    const localButtonNames = [];
+
+    const fullWidthProp = {
+        type: 'JSXAttribute',
+        name: 'width',
+        value: {
+            type: 'StringLiteral',
+            value: '100%'
+        }
+    };
+
+    ast
+        .find(j.ImportDeclaration, decl => decl.source.value === '@freenow/wave')
+        .forEach(decl => {
+            j(decl)
+                .find(j.ImportSpecifier)
+                .forEach(spec => {
+                    if (spec.node.imported.name === 'Button' || spec.node.imported.name === 'TextButton') {
+                        localButtonNames.push(spec.node.local.name);
+                    }
+                });
+        });
+
+    ast
+        .find(j.JSXElement, {
+            openingElement: {
+                name: {
+                    name: name => {
+                        return localButtonNames.includes(name);
+                    }
+                }
+            }
+        })
+        .forEach(el => {
+            j(el)
+                .find(j.JSXAttribute, {
+                    name: name => {
+                        return name.name === 'block';
+                    }
+                })
+                .forEach(attr => {
+                    if (attr.value.value) {
+                        j(attr).find(j.Literal).forEach((literal) => {
+                            if (literal.value.value === false) {
+                                j(attr).remove();
+                            } else {
+                                j(attr).replaceWith(fullWidthProp);
+                            }
+                        });
+                    } else {
+                        j(attr).replaceWith(fullWidthProp);
+                    }
+                });
+        });
+}
+
+
+module.exports = (file: FileInfo, api: API) => {
+    const j = api.jscodeshift;
+    const ast = j(file.source);
+
+    transformBlockProperty(j, ast)
+
+    return ast.toSource()
+};

--- a/docs/migrating.mdx
+++ b/docs/migrating.mdx
@@ -1,0 +1,30 @@
+---
+name: Migrating
+route: /migrating
+cardHeadline: Migrating
+cardSubHeadline: Migrating from one major version to the next with ease.
+---
+
+## From v1 to v2
+
+A codemod exists to upgrade your components for this version.
+
+```bash
+npx jscodeshift -t node_modules/@freenow/wave/codemods/v2.ts path/to/src
+```
+
+### Button and TextButton
+
+The `block` property used to act as a shortcut to give the button components a width of 100%. In the future, use the `width` property
+directly. It uses the styled-system variable, which is a lot more flexible than just the boolean flag.
+
+
+## Codemods
+
+Codemods are scripted transformations that you can run on your code to take care of most of the repetitive work involved
+in upgrading from one major version to the next. The codemod instructions for each major release assume that your code
+has already been upgraded to the previous major release. If this is not the case, you should run the codemods for all
+previous major versions first. Beware that codemods are not 100% fool-proof and may break your code.
+
+If you're working in a typescript environment, you need to add `--parser=tsx` to the command in each codemod command to
+allow jscodeshift to parse your typescript/jsx files.

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
     title: `Wave`,
-    menu: ['Get Started', 'Changelog', 'Accessibility', 'Browser support', 'Contributing', 'Essentials', 'Components'],
+    menu: ['Get Started', 'Accessibility', 'Browser support', 'Contributing', 'Migrating', 'Essentials', 'Components', 'Changelog'],
     ignore: ['CONTRIBUTING.md', 'README.md', 'SECURITY.md', 'MAINTAINERS.md', 'fixtures/**/*.md', '.idea/**/*'],
     propsParser: false,
     typescript: true,

--- a/fixtures/typescript-build/src/index.tsx
+++ b/fixtures/typescript-build/src/index.tsx
@@ -63,8 +63,6 @@ const TestButton: React.FC = () => (
         <Button variant="danger" />
         <Button size="small" />
         <Button size="medium" />
-        <Button block />
-        <Button block={false} />
         <Button onClick={voidFunction} />
     </>
 );
@@ -82,8 +80,6 @@ const TestTextButton: React.FC = () => (
         <TextButton variant="danger" />
         <TextButton size="small" />
         <TextButton size="medium" />
-        <TextButton block />
-        <TextButton block={false} />
         <TextButton onClick={voidFunction} />
     </>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,6 +1147,33 @@
                 "@babel/types": "^7.8.3"
             }
         },
+        "@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
+            "integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
         "@babel/helper-split-export-declaration": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
@@ -1160,6 +1187,12 @@
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
             "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+            "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+            "dev": true
         },
         "@babel/helper-wrap-function": {
             "version": "7.8.3",
@@ -1327,6 +1360,23 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-flow": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+            "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+                    "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -1540,6 +1590,24 @@
             "requires": {
                 "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
                 "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+            "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/plugin-syntax-flow": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+                    "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -1928,6 +1996,25 @@
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/preset-flow": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+            "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5",
+                "@babel/helper-validator-option": "^7.14.5",
+                "@babel/plugin-transform-flow-strip-types": "^7.14.5"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+                    "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
                     "dev": true
                 }
             }
@@ -5912,6 +5999,51 @@
                 "axe-core": "^3.0.3"
             }
         },
+        "@types/jscodeshift": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@types/jscodeshift/-/jscodeshift-0.11.1.tgz",
+            "integrity": "sha512-Luj54uIjTiSRAv5bqJBg8gNE8WF81oq4Xs+P0R4An2DroXFXMJBLcaGfV8VbsnpUCa5wR9KtOYKXvRZMKwabrg==",
+            "dev": true,
+            "requires": {
+                "ast-types": "^0.14.1",
+                "recast": "^0.20.3"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.14.2",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+                    "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.0.1"
+                    }
+                },
+                "recast": {
+                    "version": "0.20.4",
+                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz",
+                    "integrity": "sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==",
+                    "dev": true,
+                    "requires": {
+                        "ast-types": "0.14.2",
+                        "esprima": "~4.0.0",
+                        "source-map": "~0.6.1",
+                        "tslib": "^2.0.1"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+                    "dev": true
+                }
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -9724,6 +9856,12 @@
                 "color-name": "^1.0.0",
                 "simple-swizzle": "^0.2.2"
             }
+        },
+        "colorette": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+            "dev": true
         },
         "colors": {
             "version": "1.4.0",
@@ -14086,6 +14224,12 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
             "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+            "dev": true
+        },
+        "flow-parser": {
+            "version": "0.155.0",
+            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.155.0.tgz",
+            "integrity": "sha512-DegBwxIjw8ZmgLO9Qae/uSDWlioenV7mbfMoPem97y1OZVxlTAXNVHt5JthwrGLwk4kpmHQ3VRcp1Jxj84NcWw==",
             "dev": true
         },
         "flush-write-stream": {
@@ -20766,6 +20910,613 @@
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "dev": true
+        },
+        "jscodeshift": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.13.0.tgz",
+            "integrity": "sha512-FNHLuwh7TeI0F4EzNVIRwUSxSqsGWM5nTv596FK4NfBnEEKFpIcyFeG559DMFGHSTIYA5AY4Fqh2cBrJx0EAwg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.13.16",
+                "@babel/parser": "^7.13.16",
+                "@babel/plugin-proposal-class-properties": "^7.13.0",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
+                "@babel/plugin-proposal-optional-chaining": "^7.13.12",
+                "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+                "@babel/preset-flow": "^7.13.13",
+                "@babel/preset-typescript": "^7.13.0",
+                "@babel/register": "^7.13.16",
+                "babel-core": "^7.0.0-bridge.0",
+                "colors": "^1.1.2",
+                "flow-parser": "0.*",
+                "graceful-fs": "^4.2.4",
+                "micromatch": "^3.1.10",
+                "neo-async": "^2.5.0",
+                "node-dir": "^0.1.17",
+                "recast": "^0.20.4",
+                "temp": "^0.8.4",
+                "write-file-atomic": "^2.3.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+                    "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.14.5"
+                    }
+                },
+                "@babel/compat-data": {
+                    "version": "7.14.7",
+                    "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+                    "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+                    "dev": true
+                },
+                "@babel/core": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+                    "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/generator": "^7.14.5",
+                        "@babel/helper-compilation-targets": "^7.14.5",
+                        "@babel/helper-module-transforms": "^7.14.5",
+                        "@babel/helpers": "^7.14.6",
+                        "@babel/parser": "^7.14.6",
+                        "@babel/template": "^7.14.5",
+                        "@babel/traverse": "^7.14.5",
+                        "@babel/types": "^7.14.5",
+                        "convert-source-map": "^1.7.0",
+                        "debug": "^4.1.0",
+                        "gensync": "^1.0.0-beta.2",
+                        "json5": "^2.1.2",
+                        "semver": "^6.3.0",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+                    "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-annotate-as-pure": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+                    "integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-compilation-targets": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+                    "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/compat-data": "^7.14.5",
+                        "@babel/helper-validator-option": "^7.14.5",
+                        "browserslist": "^4.16.6",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "@babel/helper-create-class-features-plugin": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+                    "integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.14.5",
+                        "@babel/helper-function-name": "^7.14.5",
+                        "@babel/helper-member-expression-to-functions": "^7.14.5",
+                        "@babel/helper-optimise-call-expression": "^7.14.5",
+                        "@babel/helper-replace-supers": "^7.14.5",
+                        "@babel/helper-split-export-declaration": "^7.14.5"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+                    "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.14.5",
+                        "@babel/template": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+                    "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-hoist-variables": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+                    "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-member-expression-to-functions": {
+                    "version": "7.14.7",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+                    "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-module-imports": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+                    "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-module-transforms": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+                    "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.14.5",
+                        "@babel/helper-replace-supers": "^7.14.5",
+                        "@babel/helper-simple-access": "^7.14.5",
+                        "@babel/helper-split-export-declaration": "^7.14.5",
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "@babel/template": "^7.14.5",
+                        "@babel/traverse": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-optimise-call-expression": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+                    "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+                    "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+                    "dev": true
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+                    "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.14.5",
+                        "@babel/helper-optimise-call-expression": "^7.14.5",
+                        "@babel/traverse": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-simple-access": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+                    "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+                    "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+                    "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+                    "dev": true
+                },
+                "@babel/helpers": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+                    "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.14.5",
+                        "@babel/traverse": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.14.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+                    "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+                    "dev": true
+                },
+                "@babel/plugin-proposal-class-properties": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+                    "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-class-features-plugin": "^7.14.5",
+                        "@babel/helper-plugin-utils": "^7.14.5"
+                    }
+                },
+                "@babel/plugin-proposal-nullish-coalescing-operator": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+                    "integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.14.5",
+                        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+                    }
+                },
+                "@babel/plugin-proposal-optional-chaining": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+                    "integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.14.5",
+                        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+                        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+                    }
+                },
+                "@babel/plugin-syntax-typescript": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+                    "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.14.5"
+                    }
+                },
+                "@babel/plugin-transform-modules-commonjs": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.5.tgz",
+                    "integrity": "sha512-en8GfBtgnydoao2PS+87mKyw62k02k7kJ9ltbKe0fXTHrQmG6QZZflYuGI1VVG7sVpx4E1n7KBpNlPb8m78J+A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.14.5",
+                        "@babel/helper-plugin-utils": "^7.14.5",
+                        "@babel/helper-simple-access": "^7.14.5",
+                        "babel-plugin-dynamic-import-node": "^2.3.3"
+                    }
+                },
+                "@babel/plugin-transform-typescript": {
+                    "version": "7.14.6",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.6.tgz",
+                    "integrity": "sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-class-features-plugin": "^7.14.6",
+                        "@babel/helper-plugin-utils": "^7.14.5",
+                        "@babel/plugin-syntax-typescript": "^7.14.5"
+                    }
+                },
+                "@babel/preset-typescript": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz",
+                    "integrity": "sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.14.5",
+                        "@babel/helper-validator-option": "^7.14.5",
+                        "@babel/plugin-transform-typescript": "^7.14.5"
+                    }
+                },
+                "@babel/register": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.14.5.tgz",
+                    "integrity": "sha512-TjJpGz/aDjFGWsItRBQMOFTrmTI9tr79CHOK+KIvLeCkbxuOAk2M5QHjvruIMGoo9OuccMh5euplPzc5FjAKGg==",
+                    "dev": true,
+                    "requires": {
+                        "clone-deep": "^4.0.1",
+                        "find-cache-dir": "^2.0.0",
+                        "make-dir": "^2.1.0",
+                        "pirates": "^4.0.0",
+                        "source-map-support": "^0.5.16"
+                    }
+                },
+                "@babel/template": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+                    "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/parser": "^7.14.5",
+                        "@babel/types": "^7.14.5"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.14.7",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+                    "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.14.5",
+                        "@babel/generator": "^7.14.5",
+                        "@babel/helper-function-name": "^7.14.5",
+                        "@babel/helper-hoist-variables": "^7.14.5",
+                        "@babel/helper-split-export-declaration": "^7.14.5",
+                        "@babel/parser": "^7.14.7",
+                        "@babel/types": "^7.14.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.14.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+                    "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.14.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ast-types": {
+                    "version": "0.14.2",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+                    "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.0.1"
+                    }
+                },
+                "babel-plugin-dynamic-import-node": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+                    "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+                    "dev": true,
+                    "requires": {
+                        "object.assign": "^4.1.0"
+                    }
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "browserslist": {
+                    "version": "4.16.6",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+                    "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001219",
+                        "colorette": "^1.2.2",
+                        "electron-to-chromium": "^1.3.723",
+                        "escalade": "^3.1.1",
+                        "node-releases": "^1.1.71"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001243",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+                    "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
+                    "dev": true
+                },
+                "clone-deep": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+                    "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4",
+                        "kind-of": "^6.0.2",
+                        "shallow-clone": "^3.0.0"
+                    }
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.770",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.770.tgz",
+                    "integrity": "sha512-Kyh8DGK1KfEZuYKIHvuOmrKotsKZQ+qBkDIWHciE3QoFkxXB1KzPP+tfLilSHAfxTON0yYMnFCWkQtUOR7g6KQ==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "gensync": {
+                    "version": "1.0.0-beta.2",
+                    "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+                    "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.6",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "node-releases": {
+                    "version": "1.1.73",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+                    "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+                    "dev": true
+                },
+                "recast": {
+                    "version": "0.20.4",
+                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz",
+                    "integrity": "sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==",
+                    "dev": true,
+                    "requires": {
+                        "ast-types": "0.14.2",
+                        "esprima": "~4.0.0",
+                        "source-map": "~0.6.1",
+                        "tslib": "^2.0.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                            "dev": true
+                        }
+                    }
+                },
+                "shallow-clone": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+                    "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+                    "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                }
+            }
         },
         "jsdom": {
             "version": "15.2.1",
@@ -31857,6 +32608,26 @@
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
                         "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "temp": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+            "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+            "dev": true,
+            "requires": {
+                "rimraf": "~2.6.2"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
         "url": "https://github.com/freenowtech/wave.git"
     },
     "files": [
-        "lib/"
+        "lib/",
+        "codemods/"
     ],
     "license": "Apache-2.0",
     "peerDependencies": {
@@ -63,6 +64,7 @@
         "@testing-library/user-event": "^12.8.3",
         "@types/jest": "^25.1.4",
         "@types/jest-axe": "^3.2.1",
+        "@types/jscodeshift": "^0.11.1",
         "@types/react": "^16.9.26",
         "@types/react-dom": "^16.9.5",
         "@types/react-transition-group": "^4.2.4",
@@ -76,6 +78,7 @@
         "jest-axe": "^3.4.0",
         "jest-date-mock": "^1.0.8",
         "jest-styled-components": "^7.0.2",
+        "jscodeshift": "^0.13.0",
         "minimatch": "^3.0.4",
         "prettier": "^2.0.2",
         "pretty-quick": "^2.0.1",

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { compose, margin, MarginProps, ResponsiveValue, variant, width, WidthProps } from 'styled-system';
 
 import { theme } from '../../essentials/theme';
-import { deprecatedProperty } from '../../utils/deprecatedProperty';
 import { get } from '../../utils/themeGet';
 
 interface BaseButtonProps
@@ -14,11 +13,6 @@ interface BaseButtonProps
      * Adjusts the size of the button
      */
     size?: ResponsiveValue<'small' | 'medium'>;
-    /**
-     * Sets the button width to 100% of the parent
-     * @deprecated
-     */
-    block?: boolean;
 }
 
 const sizeVariant = variant({
@@ -39,19 +33,6 @@ const sizeVariant = variant({
     }
 });
 
-/**
- * @deprecated
- */
-function handleBlockProp({ block }: BaseButtonProps) {
-    if (block != undefined) {
-        deprecatedProperty('Button', block, 'block', 'width');
-    }
-
-    if (block) {
-        return 'width: 100%';
-    }
-}
-
 // "svg path" fill set to "inherit" to being able to transition using button variants
 const BaseButton = styled.button.attrs({ theme })<BaseButtonProps>`
     align-items: center;
@@ -65,7 +46,6 @@ const BaseButton = styled.button.attrs({ theme })<BaseButtonProps>`
     justify-content: center;
     text-align: center;
     text-decoration: none;
-    ${handleBlockProp};
 
     &:disabled {
         cursor: not-allowed;


### PR DESCRIPTION
This is the first of a few PRs to mark the next major version for wave. I have introduced a migration guide and a codemod framework, which we can use to enable developers to seamlessly migrate to the next major version.

It's using `jscodeshift` to transform the files, which is the de-facto standard when it comes to writing codemods for javascript-based projects. Tried it in three projects and found a few places that were still using the `block` property. 

Let me know what you think of this approach and if you're willing to invest the time of writing codemods for all breaking changes. From experience, having a migration guide is so helpful when upgrading to a new version, because you don't have to dig through all the changes to figure out all the changes you have to perform.

I will also have to target the `next` branch when this should continue.

Closes #16 