### PR TITLE
feat: add placeholder for the select component

### DIFF
--- a/src/components/Select/Select.spec.tsx
+++ b/src/components/Select/Select.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Select } from './Select';
-import userEvent from '@testing-library/user-event';
 
 describe('Select', () => {
     it('renders with default props', () => {
@@ -19,6 +19,26 @@ describe('Select', () => {
         userEvent.selectOptions(screen.getByRole('combobox', { name: /wave/i }), '1');
 
         expect(screen.getByLabelText('Wave')).toHaveDisplayValue('test 1');
+    });
+
+    it('should render an empty placeholder options when provided', () => {
+        const onChangeMock = jest.fn();
+
+        render(
+            <Select
+                label="Select"
+                placeholder="placeholder"
+                defaultValue="1"
+                onChange={e => onChangeMock(e.target.value)}
+            >
+                <option value="1">test 1</option>
+            </Select>
+        );
+
+        userEvent.selectOptions(screen.getByLabelText('Select'), '');
+
+        expect(screen.getByLabelText('Select')).toHaveDisplayValue('placeholder');
+        expect(onChangeMock).toHaveBeenCalledWith('');
     });
 
     describe('variant "boxed"', () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -13,6 +13,11 @@ interface SelectProps extends BaseSelectProps, WidthProps, MarginProps {
      * Set the label for the select input
      */
     label?: string;
+
+    /**
+     * Set a placeholder for the select component, allowing users to remove their selection
+     */
+    placeholder?: string;
 }
 
 const SelectWrapper = styled.div.attrs({ theme })`
@@ -39,12 +44,16 @@ const Select: React.FC<SelectProps> = props => {
     const { marginProps, restProps: withoutMargin } = extractWrapperMarginProps(withoutClassName);
     const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
-    const { label, ...rest } = restProps;
+    const { label, children, placeholder, ...rest } = restProps;
+
     const id = useGeneratedId(props.id);
 
     return (
         <SelectWrapper {...classNameProps} {...marginProps} {...widthProps}>
-            <SelectInput {...rest} id={id} />
+            <SelectInput {...rest} id={id}>
+                {placeholder ? <option value="">{placeholder}</option> : null}
+                {children}
+            </SelectInput>
             <IconNode className="svg-icon">
                 <ChevronDownIcon />
             </IconNode>

--- a/src/components/Select/docs/Select.mdx
+++ b/src/components/Select/docs/Select.mdx
@@ -6,10 +6,14 @@ route: /components/Select
 
 import { Playground } from 'docz';
 import { Select } from '../Select';
-import { ItemWrapper } from '../../../../docs/components/ItemWrapper.ts';
-import { Headline } from '../..';
+import { Combination } from '../../../docs/Combination'
+import { SelectPropsTable } from './SelectPropsTable';
 
 # Select
+
+## Properties
+
+<SelectPropsTable />
 
 ## Usage
 
@@ -59,167 +63,10 @@ Errors are shown just in the cases the field is mandatory and just after user cl
 - Remove options that rarely get used.
 - Remove the options that we know cannot be selected (eg: countries where we don’t work)
 
-## Component
-
-### Default
-
-<ItemWrapper gridTemplate="60% 1fr">
-    <Select label="Boxed">
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select size="small" label="Boxed Small">
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" label="Bottom Lined">
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" size="small" label="Bottom Lined Small">
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-</ItemWrapper>
-
-### Error States
-
-<ItemWrapper gridTemplate="60% 1fr">
-    <Select label="Boxed" error>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select size="small" label="Boxed Small" error>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" label="Bottom Lined" error>
-        <option>Scooter</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" size="small" label="Bottom Lined Small" error>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-</ItemWrapper>
-
-### Disabled States
-
-<ItemWrapper gridTemplate="60% 1fr">
-    <Select label="Boxed" disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select size="small" label="Boxed Small" disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" label="Bottom Lined" disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" size="small" label="Bottom Lined Small" disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-</ItemWrapper>
-
-<ItemWrapper mt={4} gridTemplate="60% 1fr" inverted>
-    <Headline as="h3" inverted>
-        Inverted
-    </Headline>
-    <div></div>
-    <Select label="Boxed" inverted>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select size="small" label="Boxed Small" inverted>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" label="Bottom Lined" inverted>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" size="small" label="Bottom Lined Small" inverted>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-</ItemWrapper>
-
-<ItemWrapper gridTemplate="60% 1fr" inverted>
-    <Headline as="h3" inverted>
-        Error States
-    </Headline>
-    <div></div>
-    <Select label="Boxed" inverted error>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select size="small" label="Boxed Small" inverted error>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" label="Bottom Lined" inverted error>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" size="small" label="Bottom Lined Small" inverted error>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-</ItemWrapper>
-
-<ItemWrapper gridTemplate="60% 1fr" inverted>
-    <Headline as="h3" inverted>
-        Disabled States
-    </Headline>
-    <div></div>
-    <Select label="Boxed" inverted disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select size="small" label="Boxed Small" inverted disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" label="Bottom Lined" inverted disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-    <Select variant="bottom-lined" size="small" label="Bottom Lined Small" inverted disabled>
-        <option>Scooter</option>
-        <option>Ride (PHV)</option>
-        <option>Taxi</option>
-    </Select>
-</ItemWrapper>
-
-## Playground
+## Examples
 
 <Playground>
-    <Select variant="bottom-lined" size="small" label="City">
+    <Select variant="bottom-lined" size="small" label="City" mb={2}>
         <option>Scooter</option>
         <option>Ride (PHV)</option>
         <option>Taxi</option>
@@ -252,3 +99,8 @@ it('can be selected by label', () => {
     expect(screen.getByLabelText('Example')).toHaveDisplayValue('test 1');
 });
 ```
+
+## Combinations
+<Combination variant={["boxed", "bottom-lined"]} size={["medium", "small"]} inverted={[false, true]} error={[false, true]}>
+    {(props, i) => <Select key={i} label="Select label" {...props}><option>Option 1</option><option>Option 2</option></Select>}
+</Combination>

--- a/src/components/Select/docs/Select.mdx
+++ b/src/components/Select/docs/Select.mdx
@@ -39,6 +39,11 @@ They mainly appear in forms but they can also be in other places, like dialog bo
 3. The user can then select a single option from that list.
 4. The input is updated to show the option selected by the user
 
+### Unselect option
+
+Passing the `placeholder` will allow users to unselect their selected option. The value sent to the `onChange` handler
+will be an empty string.
+
 ## Error state
 
 Errors are shown just in the cases the field is mandatory and just after user clicks the send/save button in the form and never after leaving the select.
@@ -218,6 +223,12 @@ Errors are shown just in the cases the field is mandatory and just after user cl
         <option>Scooter</option>
         <option>Ride (PHV)</option>
         <option>Taxi</option>
+    </Select>
+    <br/>
+    <Select label="City" placeholder="Select your destination">
+        <option>Barcelona</option>
+        <option>London</option>
+        <option>Hamburg</option>
     </Select>
 </Playground>
 

--- a/src/components/Select/docs/SelectPropsTable.tsx
+++ b/src/components/Select/docs/SelectPropsTable.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { PropsTable } from '../../../docs/PropsTable';
+
+export const SelectPropsTable = () => {
+    const props = [
+        {
+            name: 'variant',
+            type: '"boxed" | "bottom-lined"',
+            description: 'Define the display variant with boxed as the default',
+            defaultValue: '"boxed"'
+        },
+        {
+            name: 'size',
+            type: '"medium" | "small"',
+            description: 'Adjusts the size of the select list',
+            defaultValue: '"medium"'
+        },
+        {
+            name: 'inverted',
+            type: 'boolean',
+            description: 'Adjust colors for display on a dark background'
+        },
+        {
+            name: 'error',
+            type: 'boolean',
+            description: 'Indicate that the input contains an error'
+        },
+        {
+            name: 'label',
+            type: 'string',
+            description: 'Indicate that the input contains an error'
+        },
+        {
+            name: 'placeholder',
+            type: 'string',
+            description: 'Set a placeholder for the select component, allowing users to remove their selection'
+        }
+    ];
+    return <PropsTable props={props} />;
+};


### PR DESCRIPTION
**What:**
Adding a placeholder for the select component, closing #11.
​
**Why:**
The placeholder allows users to un-select an option in a select list.

**Media:**
<img width="300" alt="image" src="https://user-images.githubusercontent.com/8927747/125095702-bfc55000-e0d4-11eb-9d78-6111523379d1.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/8927747/125095772-d10e5c80-e0d4-11eb-858e-ca493be86f2e.png">


**Checklist:**

- [x] Ready to be merged
