### PR TITLE
docs: update icon documentation to include examples and more details

### DIFF
--- a/src/docs/PropsTable.tsx
+++ b/src/docs/PropsTable.tsx
@@ -15,7 +15,7 @@ interface PropsTableProps {
 }
 
 export const PropsTable: React.FC<PropsTableProps> = ({ props }) => (
-    <div style={{ overflow: 'scroll' }}>
+    <div>
         <Table rowStyle="lines" width="100%">
             <thead>
                 <TableRow>

--- a/src/icons/docs/IconGrid.tsx
+++ b/src/icons/docs/IconGrid.tsx
@@ -1,32 +1,34 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Text } from '../../components';
-import { Colors } from '../../essentials';
+import { Box, Text } from '../../components';
+import { Checkerboard } from '../../docs/Checkerboard';
 import { IconProps } from '../IconProps';
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(6rem, auto));
     grid-gap: 2rem 1rem;
     max-width: 100%;
     margin-top: 2rem;
-    margin-bottom: 6rem;
+    margin-bottom: 2rem;
 `;
 
 const Cell = styled.div`
-    width: 10rem;
+    width: 6rem;
     word-wrap: break-word;
-`;
-
-const IconComponentWrapper = styled.div`
-    padding-bottom: 0.5rem;
-    border-bottom: 0.0625rem solid ${Colors.AUTHENTIC_BLUE_50};
 `;
 
 export const Item = ({ children, name }) => {
     return (
         <Cell key={name}>
-            <IconComponentWrapper>{children}</IconComponentWrapper>
+            <Box p={2} position="relative" flexBasis="100%">
+                <Box position="absolute" top={0} left={0} right={0} bottom={0}>
+                    <Checkerboard />
+                </Box>
+                <Box position="relative" textAlign="center">
+                    {children}
+                </Box>
+            </Box>
             <Text as="p" fontSize={1} weak mt={1}>
                 {name}
             </Text>

--- a/src/icons/docs/IconPropsTable.tsx
+++ b/src/icons/docs/IconPropsTable.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { PropsTable } from '../../docs/PropsTable';
+
+export const IconPropsTable = () => {
+    const props = [
+        {
+            name: 'color',
+            type: 'string',
+            description: 'Override the default color of the icon'
+        },
+        {
+            name: 'size',
+            type: '"medium" | "small" | number',
+            description: 'Adjusts the size of the icon with defaults or the size in pixels',
+            defaultValue: '"medium"'
+        }
+    ];
+
+    return <PropsTable props={props} />;
+};

--- a/src/icons/docs/Icons.mdx
+++ b/src/icons/docs/Icons.mdx
@@ -7,16 +7,6 @@ route: /essentials/icons
 import { Playground } from 'docz';
 
 import { Colors, Headline } from '../..';
-import * as Icons from '..';
-import { Flag } from '../Flag';
-import * as BasicIcons from '../basic';
-import * as TripIcons from '../trip';
-import * as BatteryIcons from '../battery';
-import * as MobilityIcons from '../mobility';
-import * as OptionsIcons from '../options';
-import * as PaymentIcons from '../payment';
-import * as BrandIcons from '../brands';
-import * as ServiceTypeIcons from '../service-type';
 import { IconGrid, Item } from './IconGrid';
 import { FlagSelector } from './FlagSelector';
 import { LargeFlag } from './LargeFlag';
@@ -28,64 +18,48 @@ import RadiusSvg from './images/radius-detail.svg';
 import RadiusCrossedIconSvg from './images/radius-not-used.svg';
 import ColorSvg from './images/color-detail.svg';
 import BorderSvg from './images/border-detail.svg';
+import { SearchableIconGrid } from './SearchableIconGrid'
+import { IconPropsTable } from "./IconPropsTable";
+import * as Icons from '..';
+import { Flag } from "../..";
+
 
 # Icons
 
-### Basic
-<IconGrid entries={Object.entries(BasicIcons)} />
+## Usage
 
-### Trip
-<IconGrid entries={Object.entries(TripIcons)} />
+For each icon the library exposes a specific React component, which has the same name as the icon. They will render the
+connected SVG and allow you to change the size and (with some exceptions) color to suit your needs.
 
-### Battery/Fuel
-<IconGrid entries={Object.entries(BatteryIcons)} />
+```jsx
+<AlertIcon />
+```
 
-### Multimobility
-<IconGrid entries={Object.entries(MobilityIcons)} />
+## Properties
 
-### Options
-<IconGrid entries={Object.entries(OptionsIcons)} />
+<IconPropsTable />
 
-### Payment
-<IconGrid entries={Object.entries(PaymentIcons)} />
+## Examples
 
-### Brands
-<IconGrid entries={Object.entries(BrandIcons)} />
+To allow using all icons, they are imported with `import * as Icons from`, so you need to prefix every icon with `Icon.`
+so it can be rendered in the example area. This isn't necessary in your project, as you can import the icons explicitly.
 
-### Service Types
+<Playground>
+  <Icons.TrophyIcon />
+  <Icons.AlertIcon size="small" />
+  <Icons.FreeNowArrowIcon size="large" color={Colors.FREEDOM_RED_900} />
+</Playground>
 
-#### 28x28
-<IconGrid>
-    <Item name="TwoPeopleCircleIcon"><ServiceTypeIcons.TwoPeopleCircleIcon size="large" /></Item>
-    <Item name="BoltCircleIcon"><ServiceTypeIcons.BoltCircleIcon size="large" /></Item>
-    <Item name="LeafCircleIcon"><ServiceTypeIcons.LeafCircleIcon size="large" /></Item>
-    <Item name="WheelchairCircleIcon"><ServiceTypeIcons.WheelchairCircleIcon size="large" /></Item>
-    <Item name="LiteCircleIcon"><ServiceTypeIcons.LiteCircleIcon size="large" /></Item>
-</IconGrid>
+## Available Icons
 
-#### 24x24
-<IconGrid>
-    <Item name="TwoPeopleOutlineIcon"><ServiceTypeIcons.TwoPeopleOutlineIcon /></Item>
-    <Item name="BoltOutlineIcon"><ServiceTypeIcons.BoltOutlineIcon /></Item>
-    <Item name="LeafOutlineIcon"><ServiceTypeIcons.LeafOutlineIcon /></Item>
-    <Item name="WheelchairOutlineIcon"><ServiceTypeIcons.WheelchairOutlineIcon /></Item>
-    <Item name="LabelOutlineIcon"><ServiceTypeIcons.LabelOutlineIcon /></Item>
-    <Item name="TwoPeopleSolidIcon"><ServiceTypeIcons.TwoPeopleSolidIcon /></Item>
-    <Item name="BoltSolidIcon"><ServiceTypeIcons.BoltSolidIcon /></Item>
-    <Item name="LeafSolidIcon"><ServiceTypeIcons.LeafSolidIcon /></Item>
-    <Item name="WheelchairSolidIcon"><ServiceTypeIcons.WheelchairSolidIcon /></Item>
-    <Item name="LabelSolidIcon"><ServiceTypeIcons.LabelSolidIcon /></Item>
-</IconGrid>
+<SearchableIconGrid />
 
-### Inline icons
-#### 12x12
-<IconGrid>
-    <Item name="InfoCircleOutlineIcon"><BasicIcons.InfoCircleOutlineIcon size="small" /></Item>
-    <Item name="LabelSolidIcon"><ServiceTypeIcons.LabelSolidIcon size="small" color={Colors.POSITIVE_GREEN_900} /></Item>
-    <Item name="SurgeCircleSolidIcon"><TripIcons.SurgeCircleSolidIcon size="small" /></Item>
-</IconGrid>
+## Country Flags
 
-## Flags
+This library provides flags for almost every country of the world, identified by their two-character
+([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1)) country code. The icon can be accessed by using the `<Flag />`
+component and the provided country code with the property `code`.
+
 <IconGrid>
     <Item name='code="EU"'><LargeFlag code="EU" /></Item>
     <Item name='code="DE"'><LargeFlag code="DE" /></Item>
@@ -97,11 +71,33 @@ import BorderSvg from './images/border-detail.svg';
     <Item name='code="RO"'><LargeFlag code="RO" /></Item>
     <Item name='code="IT"'><LargeFlag code="IT" /></Item>
     <Item name='code="SE"'><LargeFlag code="SE" /></Item>
+    <Item name='code="US"'><LargeFlag code="US" /></Item>
 </IconGrid>
+
+```jsx
+<Flag code="US" />
+```
 
 It is also possible to preview all flags included in this library with the selector below.
 
 <FlagSelector />
+
+### Special Flags
+
+There are a few additional, special flags included in this library, that do not represent a single country. You can
+find them below.
+
+<IconGrid>
+  <Item name='code="EU"'><LargeFlag code="EU" /></Item>
+  <Item name='code="WW"'><LargeFlag code="WW" /></Item>
+  <Item name='code="CAF"'><LargeFlag code="CAF" /></Item>
+  <Item name='code="CAS"'><LargeFlag code="CAS" /></Item>
+  <Item name='code="CEU"'><LargeFlag code="CEU" /></Item>
+  <Item name='code="CNA"'><LargeFlag code="CNA" /></Item>
+  <Item name='code="CSA"'><LargeFlag code="CSA" /></Item>
+  <Item name='code="COC"'><LargeFlag code="COC" /></Item>
+</IconGrid>
+
 
 
 ## Design Documentation

--- a/src/icons/docs/SearchableIconGrid.tsx
+++ b/src/icons/docs/SearchableIconGrid.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Box, Input } from '../../components';
+import * as BasicIcons from '../basic';
+import * as BatteryIcons from '../battery';
+import * as BrandIcons from '../brands';
+import * as MobilityIcons from '../mobility';
+import * as OptionsIcons from '../options';
+import * as PaymentIcons from '../payment';
+import * as TripIcons from '../trip';
+import * as ServiceTypeIcons from '../service-type';
+
+import { IconGrid } from './IconGrid';
+
+export const SearchableIconGrid = () => {
+    const [searchQuery, setSearchQuery] = useState('');
+
+    const visibleIcons = []
+        .concat(Object.entries(BasicIcons))
+        .concat(Object.entries(TripIcons))
+        .concat(Object.entries(BatteryIcons))
+        .concat(Object.entries(MobilityIcons))
+        .concat(Object.entries(OptionsIcons))
+        .concat(Object.entries(PaymentIcons))
+        .concat(Object.entries(BrandIcons))
+        .concat(Object.entries(ServiceTypeIcons));
+
+    return (
+        <>
+            <Input
+                width="100%"
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                placeholder="Search icons..."
+            />
+            <Box>
+                <IconGrid
+                    entries={visibleIcons.filter(it => {
+                        if (searchQuery) {
+                            return !!it[0].toLowerCase().includes(searchQuery.toLowerCase());
+                        }
+
+                        return true;
+                    })}
+                />
+            </Box>
+        </>
+    );
+};


### PR DESCRIPTION
Adding additional documentation for the exported icons with a searchable icon list and a couple of explanations on how to use the Icon and Flag components. Closes #15 
​​
<img width="1792" alt="Screenshot 2021-07-13 at 22 18 30" src="https://user-images.githubusercontent.com/8927747/125519843-c63af483-b4d6-4a32-839e-9a5719ffd6a5.png">
<img width="1792" alt="Screenshot 2021-07-13 at 22 18 38" src="https://user-images.githubusercontent.com/8927747/125519860-c8761ae5-1abb-4f90-9bde-3d46d05245b1.png">
