### PR TITLE
ci: add prerelease flag for next branch

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    branches: ['main', 'next'],
+    branches: ['main', { name: 'next', prerelease: true }],
     plugins: [
         [
             '@semantic-release/commit-analyzer',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

Add flag to publish pre-releases from `next` branch
​
**Why:**

We don't want to accidentally publish the next major version.
​
**How:**

Use `prerelease` option in `semantic-release`

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
