### PR TITLE
fix: remove Toggle margin

### DIFF
--- a/src/components/Toggle/Input.tsx
+++ b/src/components/Toggle/Input.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Colors } from '../../essentials';
 import { Slide } from './Slide';
 
 interface InputProps {
@@ -10,6 +9,7 @@ interface InputProps {
 const Input = styled.input<InputProps>`
     height: 0;
     width: 0;
+    margin: 0;
     visibility: hidden;
 
     &:checked + ${/*sc-selector*/ Slide}::before {

--- a/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -44,6 +44,7 @@ exports[`Toggle renders the checked style 1`] = `
 .c1 {
   height: 0;
   width: 0;
+  margin: 0;
   visibility: hidden;
 }
 
@@ -131,6 +132,7 @@ exports[`Toggle renders the disabled checked style 1`] = `
 .c1 {
   height: 0;
   width: 0;
+  margin: 0;
   visibility: hidden;
 }
 
@@ -221,6 +223,7 @@ exports[`Toggle renders the disabled style 1`] = `
 .c1 {
   height: 0;
   width: 0;
+  margin: 0;
   visibility: hidden;
 }
 
@@ -310,6 +313,7 @@ exports[`Toggle renders the error checked style 1`] = `
 .c1 {
   height: 0;
   width: 0;
+  margin: 0;
   visibility: hidden;
 }
 
@@ -399,6 +403,7 @@ exports[`Toggle renders the error style 1`] = `
 .c1 {
   height: 0;
   width: 0;
+  margin: 0;
   visibility: hidden;
 }
 
@@ -485,6 +490,7 @@ exports[`Toggle renders with default props 1`] = `
 .c1 {
   height: 0;
   width: 0;
+  margin: 0;
   visibility: hidden;
 }
 


### PR DESCRIPTION
**What:**
Remove default margin for `Toggle` component
​
**Why:**
The `Toggle` component had an unexpected margin on the left.
Closes #167 
​
**How:**
- Set margin as 0 for `Toggle` component's inner `Input`
- Update snapshots​

**Media:**
The margin before
![Screenshot 2021-08-09 at 11 38 48](https://user-images.githubusercontent.com/46452321/128687179-d847c91e-d86a-4d7c-9620-fd37215df085.png)

- [x] Ready to be merged
