### PR TITLE
docs: update PR template for GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ merge of your pull request!
 -->
 
 **What:**
-<!-- Declarative and short sentence of what this PR accomplish. If the PR contains visual changes, please add the design-review label to the PR -->
+<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->
 ​
 **Why:**
 <!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ merge of your pull request!
 -->
 
 **What:**
-<!-- Declarative and short sentence of what this PR accomplish -->
+<!-- Declarative and short sentence of what this PR accomplish. If the PR contains visual changes, please add the design-review label to the PR -->
 ​
 **Why:**
 <!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->


### PR DESCRIPTION
**What:**
Add explanation on what to do with visual changes: add new design-review label.​

**Why:**
To allow designers to review changes that they are able to properly review. It helps them prioritise their work without having to look through all technical PRs.
​