### PR TITLE
docs: add versioning policy

### DIFF
--- a/docs/versioning-policy.mdx
+++ b/docs/versioning-policy.mdx
@@ -1,0 +1,22 @@
+---
+name: Versioning Policy
+route: /versioning-policy
+cardHeadline: Versioning Policy
+cardSubHeadline: Predictable and consistent versions for Wave
+---
+
+## Semantic Versioning
+
+Our goal is to release update to this library without breaking anyone's projects. Therefore, we are using [SemVer](https://semver.org)
+which has the following release types.
+
+- **Major** versions contain breaking changes and may also contain sweeping visual changes, like changing colors (usually includes a codemods).
+- **Minor** versions include new components or functionality and properties for existing components.
+- **Patch** versions provide internal fixes, documentation changes or package upgrades (anything that does not affect the consumers of this library).
+
+
+### Deprecations
+
+When deciding on the deprecation of a feature or component in the next major version, we add a warning indicating
+the feature is scheduled for deprecation or removal. This is sent to the console in development builds and excluded in
+production builds.

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
     title: `Wave`,
-    menu: ['Get Started', 'Changelog', 'Accessibility', 'Browser support', 'Contributing', 'Essentials', 'Components'],
+    menu: ['Get Started', 'Changelog', 'Accessibility', 'Browser support', 'Contributing', 'Versioning Policy', 'Essentials', 'Components'],
     ignore: ['CONTRIBUTING.md', 'README.md', 'SECURITY.md', 'MAINTAINERS.md', 'fixtures/**/*.md', '.idea/**/*'],
     propsParser: false,
     typescript: true,


### PR DESCRIPTION
**What:**
In this PR we are documenting our versioning policy and add details on what is considered a major, minor and patch versions. 
​
**Why:**
With this additional documentation, we aim to clearly explain which change causes which version number to increase.
