### PR TITLE
fix: re-enabling and fixing the tests for PhoneInput, resolves #27

### DIFF
--- a/src/components/PhoneInput/PhoneInput.spec.tsx
+++ b/src/components/PhoneInput/PhoneInput.spec.tsx
@@ -12,7 +12,7 @@ const selectOption = async (currentValueText: string, selectOptionText: string) 
 //
 // I disabled the tests for now and created an issue to fix this see: https://github.com/freenowtech/wave/issues/27
 // eslint-disable-next-line jest/no-disabled-tests
-describe.skip('PhoneInput', () => {
+describe('PhoneInput', () => {
     const defaultCountry = { value: 'DE', label: 'Germany', dialCode: '+49' };
 
     it('should call the country change handler when the user selects a country', async () => {
@@ -35,7 +35,9 @@ describe.skip('PhoneInput', () => {
     it('should focus on national number input after selecting a country', async () => {
         render(<PhoneInput country={defaultCountry} label="Phone Number" />);
 
-        await selectOption(defaultCountry.dialCode, 'Spain (España) +34');
+        // not all the countries are rendered at one go, they are rendered as you scroll
+        // so select a country that will come at the top, for example Andorra
+        await selectOption(defaultCountry.dialCode, 'Andorra +376');
 
         expect(document.activeElement).toEqual(screen.getByLabelText('Phone Number'));
     });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->
This PR re-enables and fixes the tests for `PhoneInput`
​
**Why:**

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
Resolves #27, the speed issue was already fixed with an update to the `SelectList` component
​
**How:**

<!-- Often a list of things to describe the process to accomplish this PR -->
1. Re-enable the test suite
2. Update the second test to refer to Andorra (as Spain isn't rendered until you scroll down)
​
**Media:**

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->
<img width="602" alt="Screenshot 2021-10-15 at 18 11 55" src="https://user-images.githubusercontent.com/5729666/137519396-22c04add-29f8-4784-a11e-ca646988b4f3.png">

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
