### PR TITLE
fix: adding layout props to TableHeaderCell and TableCell, fixes issue #184

### DIFF
--- a/src/components/Table/components/TableCell.tsx
+++ b/src/components/Table/components/TableCell.tsx
@@ -1,10 +1,13 @@
 import React, { ComponentPropsWithoutRef, FC, useContext } from 'react';
 import styled from 'styled-components';
-import { compose, textAlign, TextAlignProps } from 'styled-system';
+import { compose, LayoutProps, textAlign, TextAlignProps } from 'styled-system';
 import { TableContext } from '../context/TableContext';
 import { TableProps } from './Table';
 
-type TableCellProps = Pick<TableProps, 'rowSize' | 'columnSpace'> & ComponentPropsWithoutRef<'td'> & TextAlignProps;
+type TableCellProps = Pick<TableProps, 'rowSize' | 'columnSpace'> &
+    ComponentPropsWithoutRef<'td'> &
+    TextAlignProps &
+    LayoutProps;
 
 const TableCellElement = styled.td<TableCellProps>`
     height: ${p => p.rowSize};

--- a/src/components/Table/components/TableHeaderCell.tsx
+++ b/src/components/Table/components/TableHeaderCell.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentPropsWithoutRef, FC, useContext } from 'react';
 import styled from 'styled-components';
-import { compose, textAlign, TextAlignProps } from 'styled-system';
+import { compose, LayoutProps, textAlign, TextAlignProps } from 'styled-system';
 import { Colors } from '../../../essentials';
 import { theme } from '../../../essentials/theme';
 import { get } from '../../../utils/themeGet';
@@ -9,7 +9,8 @@ import { TableProps } from './Table';
 
 type TableHeaderCellProps = Pick<TableProps, 'rowSize' | 'columnSpace'> &
     ComponentPropsWithoutRef<'th'> &
-    TextAlignProps;
+    TextAlignProps &
+    LayoutProps;
 
 const TableHeaderCellElement = styled.th.attrs({ theme })<TableHeaderCellProps>`
     border-bottom: 0.0625rem solid ${Colors.AUTHENTIC_BLUE_550} !important;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->
This PR is to add `LayoutProps` to the `TableHeaderCell` and `TableCell` components
​
**Why:**

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->

​This resolves #184. Not sure if this will trigger a more general discussion about the implementation, because `LayoutProps` seems generic enough to exist on a lot of components in wave, but don't _(maybe because we have `Box`?)_, but trying to fix it anyway as it makes sense to me.
**How:**

<!-- Often a list of things to describe the process to accomplish this PR -->

​
**Media:**

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
