### PR TITLE
feature: Add Divider component to Wave

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -9,13 +9,12 @@
   ],
   "rules": {
     "declaration-empty-line-before": null,
-    "unit-whitelist": [
-      "rem",
-      "deg",
-      "fr",
-      "ms",
-      "%"
-    ],
+    "declaration-property-unit-whitelist": {
+      "/.*/": ["rem", "deg", "fr", "ms", "%", "px"]
+    },
+    "declaration-property-value-blacklist": {
+      "/.*/": ["(\\d+[1]+px|[^1]+px)"]
+    },
     "value-keyword-case": ["lower", { "ignoreKeywords": ["dummyValue"] }]
   }
 }

--- a/src/components/Divider/Divider.spec.tsx
+++ b/src/components/Divider/Divider.spec.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { Divider } from './Divider';
+
+describe('Divider', () => {
+    it('renders horizontal divider by default when not passing any props', () => {
+        render(<Divider />);
+        expect(screen.getByTestId('horizontal-divider')).toBeInTheDocument();
+        expect(screen.queryByTestId('vertical-divider')).not.toBeInTheDocument();
+    });
+
+    it('renders vertical divider when passing vertical prop', () => {
+        render(<Divider vertical />);
+        expect(screen.getByTestId('vertical-divider')).toBeInTheDocument();
+        expect(screen.queryByTestId('horizontal-divider')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/Divider/Divider.spec.tsx
+++ b/src/components/Divider/Divider.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Divider } from './Divider';
 
 describe('Divider', () => {
-    it('renders horizontal divider by default when not passing any props', () => {
+    it('renders a horizontal divider by default when not passing any props', () => {
         render(<Divider />);
         expect(screen.getByTestId('horizontal-divider')).toBeInTheDocument();
         expect(screen.queryByTestId('vertical-divider')).not.toBeInTheDocument();

--- a/src/components/Divider/Divider.spec.tsx
+++ b/src/components/Divider/Divider.spec.tsx
@@ -9,7 +9,7 @@ describe('Divider', () => {
         expect(screen.queryByTestId('vertical-divider')).not.toBeInTheDocument();
     });
 
-    it('renders vertical divider when passing vertical prop', () => {
+    it('renders a vertical divider when passing vertical prop', () => {
         render(<Divider vertical />);
         expect(screen.getByTestId('vertical-divider')).toBeInTheDocument();
         expect(screen.queryByTestId('horizontal-divider')).not.toBeInTheDocument();

--- a/src/components/Divider/Divider.spec.tsx
+++ b/src/components/Divider/Divider.spec.tsx
@@ -14,4 +14,22 @@ describe('Divider', () => {
         expect(screen.getByTestId('vertical-divider')).toBeInTheDocument();
         expect(screen.queryByTestId('horizontal-divider')).not.toBeInTheDocument();
     });
+
+    it('renders horizontal divider with 1rem top and bottom offset by default', () => {
+        render(<Divider />);
+        const dividerInstance = screen.getByTestId('horizontal-divider');
+        const dividerStyle = window.getComputedStyle(dividerInstance);
+
+        expect(dividerStyle.marginTop).toBe('1rem');
+        expect(dividerStyle.marginBottom).toBe('1rem');
+    });
+
+    it('renders vertical divider with 1rem left and right offset by default', () => {
+        render(<Divider vertical />);
+        const dividerInstance = screen.getByTestId('vertical-divider');
+        const dividerStyle = window.getComputedStyle(dividerInstance);
+
+        expect(dividerStyle.marginLeft).toBe('1rem');
+        expect(dividerStyle.marginRight).toBe('1rem');
+    });
 });

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -18,59 +18,31 @@ interface DividerProps extends SpaceProps {
 }
 
 const HorizontalLine: StyledComponent<'div', typeof theme, DividerProps, 'theme'> = styled.div.attrs({ theme })<
-    DividerProps
+    Pick<SpaceProps, 'my'>
 >`
     width: 100%;
-    margin: 0 auto;
+    margin-left: auto;
+    margin-right: auto;
     border: 0;
-    border-top: 0.06rem solid ${get('semanticColors.border.primary')};
+    border-top: 1px solid ${get('semanticColors.border.primary')};
 
     ${compose(space)}
 `;
 
 const VerticalLine: StyledComponent<'div', typeof theme, DividerProps, 'theme'> = styled.div.attrs({ theme })<
-    DividerProps
+    Pick<SpaceProps, 'mx'>
 >`
     display: inline-block;
     width: 0.06rem;
-    margin: 0 auto;
+    margin-top: 0;
+    margin-bottom: 0;
     border: 0;
-    border-left: 0.06rem solid ${get('semanticColors.border.primary')};
+    border-left: 1px solid ${get('semanticColors.border.primary')};
 
     ${compose(space)}
 `;
 
-/**
- * ** Primary UI element for visually separating content **
- *
- * Renders a divider UI component: horizontal or vertical line that visually separates two pieces of data, content or UI immediately next to it.
- *
- * Horizontal divider will take up full available width, vertical divider will take up full available height.
- *
- * _Divider_ renders a horizontal divider by default. Set **vertical** prop to __true__ to change divider orientation.
- *
- *
- * ---
- *
- * <br/>
- *
- * #### Divider vs. Border
- *
- * The default color of _Divider_ is $border.primary (#C6CDD4) <span style="color: #C6CDD4">⬤</span>, however...
- *
- * ** Divider is NOT a border, and should not be used as such. Please do not use this component as a border for elements. **
- *
- * Divider is naturally expected to have a certain offset from the elements it is 'dividing' or separating.
- *
- * ---
- *
- * #### Style Props
- *
- * The Divider has following design props:
- * - **offset** - set the divider offset from the content it is separating (uses _mx_, _my_ styled system props)
- *
- */
-const Divider = ({ vertical = false, offset = 0 }: DividerProps): React.ReactElement =>
+const Divider: React.FC<DividerProps> = ({ vertical = false, offset = '1rem' }: DividerProps) =>
     vertical ? (
         <VerticalLine mx={offset} data-testid="vertical-divider" />
     ) : (

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import styled, { StyledComponent } from 'styled-components';
+import { compose, space, SpaceProps } from 'styled-system';
+import { theme } from '../../essentials/theme';
+import { get } from '../../utils/themeGet';
+
+type DividerOffset = number | string;
+
+interface DividerProps extends SpaceProps {
+    /**
+     * Set the direction of the divider to vertical
+     */
+    vertical?: boolean;
+    /**
+     * Set offset / margin of the divider from the surrounding content
+     */
+    offset?: DividerOffset;
+}
+
+const HorizontalLine: StyledComponent<'div', typeof theme, DividerProps, 'theme'> = styled.div.attrs({ theme })<
+    DividerProps
+>`
+    width: 100%;
+    margin: 0 auto;
+    border: 0;
+    border-top: 0.06rem solid ${get('semanticColors.border.primary')};
+
+    ${compose(space)}
+`;
+
+const VerticalLine: StyledComponent<'div', typeof theme, DividerProps, 'theme'> = styled.div.attrs({ theme })<
+    DividerProps
+>`
+    display: inline-block;
+    width: 0.06rem;
+    margin: 0 auto;
+    border: 0;
+    border-left: 0.06rem solid ${get('semanticColors.border.primary')};
+
+    ${compose(space)}
+`;
+
+/**
+ * ** Primary UI element for visually separating content **
+ *
+ * Renders a divider UI component: horizontal or vertical line that visually separates two pieces of data, content or UI immediately next to it.
+ *
+ * Horizontal divider will take up full available width, vertical divider will take up full available height.
+ *
+ * _Divider_ renders a horizontal divider by default. Set **vertical** prop to __true__ to change divider orientation.
+ *
+ *
+ * ---
+ *
+ * <br/>
+ *
+ * #### Divider vs. Border
+ *
+ * The default color of _Divider_ is $border.primary (#C6CDD4) <span style="color: #C6CDD4">⬤</span>, however...
+ *
+ * ** Divider is NOT a border, and should not be used as such. Please do not use this component as a border for elements. **
+ *
+ * Divider is naturally expected to have a certain offset from the elements it is 'dividing' or separating.
+ *
+ * ---
+ *
+ * #### Style Props
+ *
+ * The Divider has following design props:
+ * - **offset** - set the divider offset from the content it is separating (uses _mx_, _my_ styled system props)
+ *
+ */
+const Divider = ({ vertical = false, offset = 0 }: DividerProps): React.ReactElement =>
+    vertical ? (
+        <VerticalLine mx={offset} data-testid="vertical-divider" />
+    ) : (
+        <HorizontalLine my={offset} data-testid="horizontal-divider" />
+    );
+
+export { Divider, DividerProps, DividerOffset };

--- a/src/components/Divider/docs/Divider.mdx
+++ b/src/components/Divider/docs/Divider.mdx
@@ -31,7 +31,7 @@ Divider is naturally expected to have a certain offset from the elements it is '
 <br/>
 
 ### Style Props
-The Divider has following design props:
+The Divider has the following design props:
 - **offset** - set the divider offset from the content it is separating (uses _mx_, _my_ styled system props)
 <br/>
 <br/>

--- a/src/components/Divider/docs/Divider.mdx
+++ b/src/components/Divider/docs/Divider.mdx
@@ -7,7 +7,7 @@ route: /components/divider
 import { Playground } from 'docz';
 import { ItemWrapper } from '../../../../docs/components/ItemWrapper.ts';
 import { Divider } from '../Divider.tsx';
-import { WrappedHorizontalDivider, WrappedVerticalDivider } from './WrappedDivider.tsx';
+import { WrappedHorizontalDivider, WrappedVerticalDivider, SectionPlaceholder } from './WrappedDivider.tsx';
 
 # Divider
 
@@ -15,33 +15,39 @@ import { WrappedHorizontalDivider, WrappedVerticalDivider } from './WrappedDivid
 
 Renders a divider UI component: horizontal or vertical line that visually separates two pieces of data, content or UI.
 <br/>
-<hr/>
 
 ### Default Behaviour
 Horizontal divider takes up full available width, vertical divider takes up full available height.
 
 Horizontal divider is rendered by default. Set **vertical** prop to __true__ to change divider orientation.
 <br/>
-<hr/>
 
 ### Divider vs Border
-
 The default color of Divider is **$border.primary** (#C6CDD4), however...
 
 **Divider is NOT a border, and should not be used as such. Please do not use this component as a border for elements.**
 
 Divider is naturally expected to have a certain offset from the elements it is 'dividing' or separating.
 <br/>
-<hr/>
 
 ### Style Props
-
 The Divider has following design props:
 - **offset** - set the divider offset from the content it is separating (uses _mx_, _my_ styled system props)
-
-<hr/>
+<br/>
+<br/>
 
 ## Usage 
+
+### Horizontal (with default offset)
+
+<ItemWrapper>
+    <WrappedHorizontalDivider offset='1rem' />
+</ItemWrapper>
+
+```jsx
+<Divider />
+```
+<br/>
 
 ### Horizontal (without offset)
 
@@ -50,22 +56,20 @@ The Divider has following design props:
 </ItemWrapper>
 
 ```jsx
-<Divider />
+<Divider offset={0} />
 ```
+<br/>
 
-<hr/> 
-
-### Horizontal (with offset)
+### Vertical (with default offset)
 
 <ItemWrapper>
-    <WrappedHorizontalDivider offset={5} />
+    <WrappedVerticalDivider offset='1rem' />
 </ItemWrapper>
 
 ```jsx
-<Divider offset={5} />
+<Divider vertical />
 ```
-
-<hr/>
+<br/>
 
 ### Vertical (without offset)
 
@@ -76,13 +80,22 @@ The Divider has following design props:
 ```jsx
 <Divider vertical />
 ```
+<br/>
 
-### Vertical (with offset)
+# Playground
 
-<ItemWrapper>
-    <WrappedVerticalDivider offset={5} />
-</ItemWrapper>
+<Playground>
+    <section>Section 1</section>
+        <Divider />
+    <section>Section 2</section>
+</Playground>
 
-```jsx
-<Divider vertical offset={5} />
-```
+<Playground>
+    {/* We need the row flow to see vertical divider */}
+    <div style={{ display: 'flex' }}>
+        <SectionPlaceholder>Section 1</SectionPlaceholder>
+        <Divider vertical />
+        <SectionPlaceholder>Section 2</SectionPlaceholder>
+    </div>
+</Playground>
+

--- a/src/components/Divider/docs/Divider.mdx
+++ b/src/components/Divider/docs/Divider.mdx
@@ -17,7 +17,7 @@ Renders a divider UI component: horizontal or vertical line that visually separa
 <br/>
 
 ### Default Behaviour
-Horizontal divider takes up full available width, vertical divider takes up full available height.
+The horizontal divider takes up the full available width and the vertical divider takes up the full available height.
 
 Horizontal divider is rendered by default. Set **vertical** prop to __true__ to change divider orientation.
 <br/>

--- a/src/components/Divider/docs/Divider.mdx
+++ b/src/components/Divider/docs/Divider.mdx
@@ -19,7 +19,7 @@ Renders a divider UI component: horizontal or vertical line that visually separa
 ### Default Behaviour
 The horizontal divider takes up the full available width and the vertical divider takes up the full available height.
 
-Horizontal divider is rendered by default. Set **vertical** prop to __true__ to change divider orientation.
+The horizontal divider is rendered by default. Set **vertical** prop to `true` to change the divider orientation.
 <br/>
 
 ### Divider vs Border

--- a/src/components/Divider/docs/Divider.mdx
+++ b/src/components/Divider/docs/Divider.mdx
@@ -1,0 +1,88 @@
+---
+name: Divider
+menu: Components
+route: /components/divider
+---
+
+import { Playground } from 'docz';
+import { ItemWrapper } from '../../../../docs/components/ItemWrapper.ts';
+import { Divider } from '../Divider.tsx';
+import { WrappedHorizontalDivider, WrappedVerticalDivider } from './WrappedDivider.tsx';
+
+# Divider
+
+**Primary UI element for visually separating content**
+
+Renders a divider UI component: horizontal or vertical line that visually separates two pieces of data, content or UI.
+<br/>
+<hr/>
+
+### Default Behaviour
+Horizontal divider takes up full available width, vertical divider takes up full available height.
+
+Horizontal divider is rendered by default. Set **vertical** prop to __true__ to change divider orientation.
+<br/>
+<hr/>
+
+### Divider vs Border
+
+The default color of Divider is **$border.primary** (#C6CDD4), however...
+
+**Divider is NOT a border, and should not be used as such. Please do not use this component as a border for elements.**
+
+Divider is naturally expected to have a certain offset from the elements it is 'dividing' or separating.
+<br/>
+<hr/>
+
+### Style Props
+
+The Divider has following design props:
+- **offset** - set the divider offset from the content it is separating (uses _mx_, _my_ styled system props)
+
+<hr/>
+
+## Usage 
+
+### Horizontal (without offset)
+
+<ItemWrapper>
+    <WrappedHorizontalDivider offset={0} />
+</ItemWrapper>
+
+```jsx
+<Divider />
+```
+
+<hr/> 
+
+### Horizontal (with offset)
+
+<ItemWrapper>
+    <WrappedHorizontalDivider offset={5} />
+</ItemWrapper>
+
+```jsx
+<Divider offset={5} />
+```
+
+<hr/>
+
+### Vertical (without offset)
+
+<ItemWrapper>
+    <WrappedVerticalDivider offset={0} />
+</ItemWrapper>
+
+```jsx
+<Divider vertical />
+```
+
+### Vertical (with offset)
+
+<ItemWrapper>
+    <WrappedVerticalDivider offset={5} />
+</ItemWrapper>
+
+```jsx
+<Divider vertical offset={5} />
+```

--- a/src/components/Divider/docs/WrappedDivider.tsx
+++ b/src/components/Divider/docs/WrappedDivider.tsx
@@ -18,7 +18,15 @@ const DividerSideElement = styled.div`
     padding: 4;
 `;
 
-const WrappedHorizontalDivider = (offset: DividerOffset): React.ReactNode => (
+const SectionPlaceholder = styled.div`
+    flex: 1;
+    height: '200px';
+    border: 1px black solid;
+    text-align: center;
+    padding: 20px;
+`;
+
+const WrappedHorizontalDivider = (offset: DividerOffset): React.ReactElement => (
     <DividerColumnWrapper>
         <DividerSideElement>Element 1</DividerSideElement>
         <Divider offset={offset} />
@@ -26,7 +34,7 @@ const WrappedHorizontalDivider = (offset: DividerOffset): React.ReactNode => (
     </DividerColumnWrapper>
 );
 
-const WrappedVerticalDivider = (offset: DividerOffset): React.ReactNode => (
+const WrappedVerticalDivider = (offset: DividerOffset): React.ReactElement => (
     <DividerWrapper>
         <DividerSideElement>Element 1</DividerSideElement>
         <Divider vertical offset={offset} />
@@ -34,4 +42,4 @@ const WrappedVerticalDivider = (offset: DividerOffset): React.ReactNode => (
     </DividerWrapper>
 );
 
-export { WrappedHorizontalDivider, WrappedVerticalDivider };
+export { WrappedHorizontalDivider, WrappedVerticalDivider, SectionPlaceholder };

--- a/src/components/Divider/docs/WrappedDivider.tsx
+++ b/src/components/Divider/docs/WrappedDivider.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Divider } from '../Divider';
+import type DividerOffset from '../Divider';
+
+const DividerWrapper = styled.div`
+    height: auto;
+    display: flex;
+    width: 100%;
+`;
+
+const DividerColumnWrapper = styled(DividerWrapper)`
+    flex-direction: column;
+`;
+
+const DividerSideElement = styled.div`
+    height: auto;
+    padding: 4;
+`;
+
+const WrappedHorizontalDivider = (offset: DividerOffset): React.ReactNode => (
+    <DividerColumnWrapper>
+        <DividerSideElement>Element 1</DividerSideElement>
+        <Divider offset={offset} />
+        <DividerSideElement>Element 2</DividerSideElement>
+    </DividerColumnWrapper>
+);
+
+const WrappedVerticalDivider = (offset: DividerOffset): React.ReactNode => (
+    <DividerWrapper>
+        <DividerSideElement>Element 1</DividerSideElement>
+        <Divider vertical offset={offset} />
+        <DividerSideElement>Element 2</DividerSideElement>
+    </DividerWrapper>
+);
+
+export { WrappedHorizontalDivider, WrappedVerticalDivider };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,6 +21,7 @@ export { Tag, TagProps } from './Tag/Tag';
 export { InlineSpinner, InlineSpinnerProps } from './InlineSpinner/InlineSpinner';
 export { TabBar, TabBarWithLink as TabBarProps } from './TabBar/TabBar';
 export { DatePicker, DateRangePicker, DateRangePickerProps, DatePickerProps } from './Datepicker';
+export { Divider, DividerProps } from './Divider/Divider';
 export { Tooltip, TooltipProps } from './Tooltip/Tooltip';
 export { Toggle, ToggleProps } from './Toggle/Toggle';
 export { Box, BoxProps } from './Box/Box';


### PR DESCRIPTION
**What:**

This PR adds a new Divider component to the Wave Design System, as per: [#218](https://github.com/freenowtech/wave/issues/218)

​
**Why:**
Closes #218 

A number of our tools that use Wave DS, including BOMT, DMT, PMT (and possibly more) have many instances of a horizontal or vertical line separating pieces of content. A Divider component is often a core component in design systems, therefore, this issue proposed the addition of new component to our Wave design system for these and other use-cases.
​
​
**Media:**
<img width="841" alt="Screenshot 2022-05-03 at 17 33 35" src="https://user-images.githubusercontent.com/14894844/166485727-1f9e4fe5-99ac-4002-88d6-f8c41d7d0816.png">
<img width="826" alt="Screenshot 2022-05-03 at 17 33 51" src="https://user-images.githubusercontent.com/14894844/166485741-672e445f-3cef-4fad-be94-9c90ed6dd484.png">

**Checklist:**
-   [x] Reviewed with designer
-   [x] Ready to merge
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
