### PR TITLE
fix: export popover component in components index

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -94,7 +94,7 @@ interface PopoverProps {
     onClose?: () => void;
 }
 
-export const Popover: React.FC<PopoverProps> = ({
+const Popover: React.FC<PopoverProps> = ({
     children,
     content = '',
     placement = 'bottom-start',
@@ -240,3 +240,5 @@ export const Popover: React.FC<PopoverProps> = ({
         </>
     );
 };
+
+export { Popover, PopoverProps };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -50,3 +50,4 @@ export { RadioButtonProps } from './RadioButton/RadioButtonProps';
 export { Offcanvas, OffcanvasProps } from './Offcanvas/Offcanvas';
 export { SelectListProps } from './SelectList/types';
 export { Row, RowProps, Column, ColumnProps } from './Grid/Grid';
+export { Popover, PopoverProps } from './Popover/Popover';


### PR DESCRIPTION
**What:**

Export `Popover` component from the components index in order to be able to import it from outside 
<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
