### PR TITLE
fix: giving singlevalue full max width to override the selectlist styles

### DIFF
--- a/src/components/PhoneInput/components/SingleValue.tsx
+++ b/src/components/PhoneInput/components/SingleValue.tsx
@@ -13,6 +13,7 @@ const StyledSingleValue = styled(components.SingleValue)`
         min-width: 1.5rem;
         margin-right: 0.5rem;
     }
+    max-width: 100%;
 `;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->

This PR sets `max-width` to `100%` for the `SingleValue` component
​
**Why:**

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->

Fixes issue #242 
​
**How:**

<!-- Often a list of things to describe the process to accomplish this PR -->

​
**Media:**

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->
<img width="1680" alt="Screenshot 2022-06-12 at 00 11 10" src="https://user-images.githubusercontent.com/5729666/173206488-53f64ec4-f542-4601-ab35-a2fa54dfa446.png">

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
