### PR TITLE
fix: display semantic colors in table and allow to filter them

### DIFF
--- a/src/essentials/Colors/docs/SemanticColorsTable.tsx
+++ b/src/essentials/Colors/docs/SemanticColorsTable.tsx
@@ -32,7 +32,7 @@ export const SemanticColorsTable: FC = () => {
     const [nameSearchInput, setNameSearchInput] = useState('');
     const flatSemanticColors = flattenObj(SemanticColors);
 
-    const filteredColorKeys = Object.keys(flatSemanticColors).filter(it => {
+    const filteredColorKeys = ([...flatSemanticColors.keys()] as string[]).filter(it => {
         if (nameSearchInput === '') {
             return true;
         }
@@ -64,13 +64,13 @@ export const SemanticColorsTable: FC = () => {
                     {filteredColorKeys.map(key => (
                         <TableRow key={key}>
                             <TableCell>
-                                <ColorBlock color={flatSemanticColors[key]} />
+                                <ColorBlock color={flatSemanticColors.get(key)} />
                             </TableCell>
                             <TableCell>
                                 <code>{key}</code>
                             </TableCell>
                             <TableCell>
-                                <code>{flatSemanticColors[key]}</code>
+                                <code>{flatSemanticColors.get(key)}</code>
                             </TableCell>
                         </TableRow>
                     ))}

--- a/src/essentials/Colors/docs/SemanticColorsTable.tsx
+++ b/src/essentials/Colors/docs/SemanticColorsTable.tsx
@@ -36,7 +36,7 @@ export const SemanticColorsTable: FC = () => {
 
     const filteredColorKeys = !nameSearchInput
         ? flatSemanticColorsKeys
-        : flatSemanticColorsKeys.filter(it => it.toLowerCase().includes(nameSearchInput.toLowerCase()));
+        : flatSemanticColorsKeys.filter(it => it.toLowerCase().includes(nameSearchInput.toLowerCase().trim()));
 
     return (
         <>

--- a/src/essentials/Colors/docs/SemanticColorsTable.tsx
+++ b/src/essentials/Colors/docs/SemanticColorsTable.tsx
@@ -28,17 +28,15 @@ const ColorBlock = styled.div<{ color: string }>`
     width: 4rem;
 `;
 
+const flatSemanticColors = flattenObj(SemanticColors);
+const flatSemanticColorsKeys = [...flatSemanticColors.keys()] as string[];
+
 export const SemanticColorsTable: FC = () => {
     const [nameSearchInput, setNameSearchInput] = useState('');
-    const flatSemanticColors = flattenObj(SemanticColors);
 
-    const filteredColorKeys = ([...flatSemanticColors.keys()] as string[]).filter(it => {
-        if (nameSearchInput === '') {
-            return true;
-        }
-
-        return it.toLowerCase().includes(nameSearchInput.toLowerCase());
-    });
+    const filteredColorKeys = !nameSearchInput
+        ? flatSemanticColorsKeys
+        : flatSemanticColorsKeys.filter(it => it.toLowerCase().includes(nameSearchInput.toLowerCase()));
 
     return (
         <>


### PR DESCRIPTION
**What:**

Fix a bug where the semantic colors where not appearing in the table in the docs.

​
**Why:**

We want to deprecate "regular old colors" in favour of semantic colors, therefore we should offer the best possible experience to our users when working with the latter.

[Check out how the colors do not appear in the table in our docs](https://wave.free-now.com/essentials/colors#functional-reference)

​
**How:**

- Properly converting a `Map` with all of the colors to an `Array` in order to iterate and `.filter` it on the table.

​
**Media:**
Before
<img width="995" alt="image" src="https://user-images.githubusercontent.com/46452321/177750217-63ac45ac-e8b1-477e-bec8-8ff55afa5ea8.png">

After
<img width="991" alt="image" src="https://user-images.githubusercontent.com/46452321/177750157-cbed4f23-bb22-44ed-a582-7682f7061701.png">

**Checklist:**

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

