### PR TITLE
Expand PhoneInput API

### DIFF
--- a/fixtures/typescript-build/src/index.tsx
+++ b/fixtures/typescript-build/src/index.tsx
@@ -21,6 +21,7 @@ import {
     Logo,
     Modal,
     Pagination,
+    PhoneInput,
     RadioButton,
     Select,
     TabBar,
@@ -443,6 +444,26 @@ const TestTooltip: React.FC = () => (
     </>
 );
 
+const TestPhoneInput = () => (
+    <>
+        <PhoneInput />
+        <PhoneInput id="hello" />
+        <PhoneInput variant="boxed" size="medium" />
+        <PhoneInput variant="bottom-lined" size="small" />
+        <PhoneInput text="my text" />
+        <PhoneInput
+            inputProps={{
+                onFocus: () => {}
+            }}
+        />
+        <PhoneInput
+            selectListProps={{
+                onFocus: () => {}
+            }}
+        />
+    </>
+);
+
 const App: React.FC = () => (
     <>
         <TestBanner />
@@ -471,6 +492,7 @@ const App: React.FC = () => (
         <TestTextarea />
         <TestToggle />
         <TestTooltip />
+        <TestPhoneInput />
     </>
 );
 

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -13,6 +13,7 @@ import { extractWrapperMarginProps } from '../../utils/extractProps';
 import { Input } from '../Input/Input';
 import { InputProps } from '../Input/InputProps';
 import { SelectList } from '../SelectList/SelectList';
+import { SelectListProps } from '../SelectList/types';
 import { DynamicWidthMenu } from './components/DynamicWidthMenu';
 import { Option } from './components/Option';
 import { SingleValue } from './components/SingleValue';
@@ -30,13 +31,22 @@ interface PhoneInputProps
     onTextChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
     country?: PhoneAreaCodeCountry;
     onCountryChange?: (country?: PhoneAreaCodeCountry) => void;
+    listPortalTarget?: SelectListProps['menuPortalTarget'];
+    inputProps?: InputProps;
+    selectListProps?: SelectListProps;
 }
 
 const Box = styled.div<LayoutProps & WidthProps>`
     ${compose(layout, widthFn, marginFn)}
 `;
 
-const PhoneInput: React.FC<PhoneInputProps> = ({ width, variant = 'boxed', ...props }: PhoneInputProps) => {
+const PhoneInput: React.FC<PhoneInputProps> = ({
+    width,
+    variant = 'boxed',
+    inputProps = {},
+    selectListProps = {},
+    ...props
+}: PhoneInputProps) => {
     const { marginProps } = extractWrapperMarginProps(props);
 
     const nationalNumberInputRef = React.createRef<HTMLDivElement>();
@@ -54,6 +64,7 @@ const PhoneInput: React.FC<PhoneInputProps> = ({ width, variant = 'boxed', ...pr
     return (
         <Box display="inline-flex" width={width} {...marginProps} ref={containerRef}>
             <SelectList
+                {...selectListProps}
                 id={`${props.id}-area-code`}
                 name={`${props.name}-area-code`}
                 value={props.country}
@@ -75,8 +86,10 @@ const PhoneInput: React.FC<PhoneInputProps> = ({ width, variant = 'boxed', ...pr
                 variant={variant}
                 size={props.size}
                 isDisabled={props.disabled}
+                menuPortalTarget={props.listPortalTarget}
             />
             <Input
+                {...inputProps}
                 id={`${props.id}-national-number`}
                 name={`${props.name}-national-number`}
                 ml={spaceBetweenInputs}

--- a/src/components/PhoneInput/docs/PhoneInput.mdx
+++ b/src/components/PhoneInput/docs/PhoneInput.mdx
@@ -53,7 +53,7 @@ return (
 
 ## Troubleshooting
 
-### The list of previxes is not fully visible
+### The list of prefixes is not fully visible
 
 If the list of prefixes is not fully visible when opened, like in [this Sandbox example](https://codesandbox.io/s/inspiring-austin-2006xl?file=/src/index.js), use `listPortalTarget` prop to attach the popup to the document's body:
 

--- a/src/components/PhoneInput/docs/PhoneInput.mdx
+++ b/src/components/PhoneInput/docs/PhoneInput.mdx
@@ -15,6 +15,10 @@ import { COUNTRIES } from '../constants';
 
 # PhoneInput
 
+The `PhoneInput` is a component to input a phone number in international format.
+
+The component consists of two controls: a select to pick a prefix and an input to type in the phone number. The select shows all the country codes available world-wide.
+
 ## Properties
 
 <PhoneInputPropsTable />
@@ -40,3 +44,9 @@ return (
     />
 );
 ```
+
+## Playground
+
+<Playground>
+    <ControlledPhoneInput label="Mobile Phone Number" />
+</Playground>

--- a/src/components/PhoneInput/docs/PhoneInput.mdx
+++ b/src/components/PhoneInput/docs/PhoneInput.mdx
@@ -61,4 +61,4 @@ If the list of prefixes is not fully visible when opened, like in [this Sandbox 
 <PhoneInput listPortalTarget={document.body} />
 ```
 
-The reason of the issue is that the prefix selection popup is rendered inside the same container as the component by default. If the container do not allow content to overflow (e.g. via `overflow: hidden;`), everything that overflows the container borders will be hidden.
+The reason of the issue is that the prefix selection popup is rendered inside the same container as the component by default. If the container does not allow content to overflow (e.g. via `overflow: hidden;`), everything that overflows the container borders will be hidden.

--- a/src/components/PhoneInput/docs/PhoneInput.mdx
+++ b/src/components/PhoneInput/docs/PhoneInput.mdx
@@ -50,3 +50,15 @@ return (
 <Playground>
     <ControlledPhoneInput label="Mobile Phone Number" />
 </Playground>
+
+## Troubleshooting
+
+### The list of previxes is not fully visible
+
+If the list of prefixes is not fully visible when opened, like in [this Sandbox example](https://codesandbox.io/s/inspiring-austin-2006xl?file=/src/index.js), use `listPortalTarget` prop to attach the popup to the document's body:
+
+```jsx
+<PhoneInput listPortalTarget={document.body} />
+```
+
+The reason of the issue is that the prefix selection popup is rendered inside the same container as the component by default. If the container do not allow content to overflow (e.g. via `overflow: hidden;`), everything that overflows the container borders will be hidden.

--- a/src/components/PhoneInput/docs/PhoneInputPropsTable.tsx
+++ b/src/components/PhoneInput/docs/PhoneInputPropsTable.tsx
@@ -74,7 +74,7 @@ export const PhoneInputPropsTable: FC = () => {
             type: 'Object',
             description:
                 'Pass props directly to the internal SelectList component used to show prefixes. ' +
-                'Any value from the `Input` component props are allowed, but props from the `PhoneInput` take precedence'
+                'Any value from the `SelectList` component props are allowed, but props from the `PhoneInput` take precedence'
         }
     ];
     return <PropsTable props={props} />;

--- a/src/components/PhoneInput/docs/PhoneInputPropsTable.tsx
+++ b/src/components/PhoneInput/docs/PhoneInputPropsTable.tsx
@@ -56,6 +56,25 @@ export const PhoneInputPropsTable: FC = () => {
             name: 'disabled',
             type: 'boolean',
             description: 'Disables both, the area code and national number inputs'
+        },
+        {
+            name: 'listPortalTarget',
+            type: 'HTMLElement',
+            description: 'HTML element which will be used as a parent for the prefix list'
+        },
+        {
+            name: 'inputProps',
+            type: 'Object',
+            description:
+                'Pass props directly to the internal input component. ' +
+                'Any value from the `Input` component props are allowed, but props from the `PhoneInput` take precedence'
+        },
+        {
+            name: 'selectListProps',
+            type: 'Object',
+            description:
+                'Pass props directly to the internal SelectList component used to show prefixes. ' +
+                'Any value from the `Input` component props are allowed, but props from the `PhoneInput` take precedence'
         }
     ];
     return <PropsTable props={props} />;

--- a/src/docs/PropsTable.tsx
+++ b/src/docs/PropsTable.tsx
@@ -32,12 +32,12 @@ export const PropsTable: React.FC<PropsTableProps> = ({ props: componentProps }:
                                 {prop.name}
                             </Text>
                         </TableCell>
-                        <TableCell>
+                        <TableCell style={{ whiteSpace: 'normal' }}>
                             <Text fontSize="inherit" fontFamily="monospace" as="p">
                                 {prop.type}
                             </Text>
                             {prop.description && (
-                                <Text weak fontSize="inherit">
+                                <Text secondary fontSize="inherit">
                                     {prop.description}
                                 </Text>
                             )}


### PR DESCRIPTION
## What

Allows to attach portals and exposes implementation level APIs
​
**Why:**

Closes #256 #259

​
**How:**

- adds `listPortalTarget` prop to be able to attach the prefixes popup to another HTML element
- adds `inputProps` and `selectListProps` props and passes them to the corresponding components. Those props has less priority than higher level props of the `PhoneInput` (e.g. `<PhoneInput id='hello' inputProps={{id: 'input'}} />` will use _hello_ as the id)
- updated the documentation
​
**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
