### PR TITLE
fix: expose padding prop and adjust z-index for Popover component

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -233,8 +233,7 @@ const Popover: React.FC<PopoverProps> = ({
                 <PopoverContentContainer
                     id="popover-content"
                     ref={setContentReference}
-                    // zIndex temporary until we have Portal component
-                    style={{ ...styles.popper, zIndex: 9999 }}
+                    style={{ ...styles.popper, zIndex: 999 }}
                     {...attributes.popper}
                 >
                     <PopoverContentWrapper ref={popoverContentRef}>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -73,6 +73,10 @@ interface PopoverProps {
      */
     content: React.ReactNode;
     /**
+     * Popover content padding
+     */
+    padding?: string | number;
+    /**
      * Optional: Specify the Popover content placement (it changes automatically if the Popover content cannot fit inside the viewport with the selected placement)
      */
     placement?: Placement;
@@ -97,6 +101,7 @@ interface PopoverProps {
 const Popover: React.FC<PopoverProps> = ({
     children,
     content = '',
+    padding = undefined,
     placement = 'bottom-start',
     offset = 5,
     isOpen = false,
@@ -233,7 +238,7 @@ const Popover: React.FC<PopoverProps> = ({
                     {...attributes.popper}
                 >
                     <PopoverContentWrapper ref={popoverContentRef}>
-                        <PopoverContent>{content}</PopoverContent>
+                        <PopoverContent padding={padding}>{content}</PopoverContent>
                     </PopoverContentWrapper>
                 </PopoverContentContainer>
             )}

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -4,20 +4,28 @@ import styled from 'styled-components';
 import { Spaces } from '../../essentials';
 import { Card } from '../Card/Card';
 
+const DEFAULT_PADDING = Spaces[2];
+
 interface PopoverContentProps {
     /**
      * Popover content (can be any valid React Element or component)
      */
     children: React.ReactNode;
+    /**
+     * Popover content padding
+     */
+    padding: string | number;
 }
 
-const PopoverContentContainer = styled(Card)`
+const PopoverContentContainer = styled(Card)<{ padding: string | number }>`
     display: block;
-    padding: ${Spaces[2]};
+    padding: ${props => props.padding};
 `;
 
-export const PopoverContent = ({ children }: PopoverContentProps): React.ReactElement => (
+export const PopoverContent = ({ padding = DEFAULT_PADDING, children }: PopoverContentProps): React.ReactElement => (
     <>
-        <PopoverContentContainer level={200}>{children}</PopoverContentContainer>
+        <PopoverContentContainer padding={padding} level={200}>
+            {children}
+        </PopoverContentContainer>
     </>
 );

--- a/src/components/Popover/docs/Popover.mdx
+++ b/src/components/Popover/docs/Popover.mdx
@@ -113,6 +113,21 @@ The Popover supports:
 ```
 <br/>
 
+### With No Padding
+
+<ItemWrapper>
+    <Popover content={'There is no padding...'} padding={0}>
+        <Button size='small' variant="secondary"><SettingsIcon size={20} style={{marginRight: 5}} /> Manage Booking</Button>
+    </Popover>
+</ItemWrapper>
+
+```jsx
+<Popover content={'There is no padding...'} padding={0}>
+    <Button size='small' variant="secondary"><SettingsIcon size={20} /> Manage Booking</Button>
+</Popover>
+```
+<br/>
+
 ## Playground
 
 <Playground>


### PR DESCRIPTION
**What:**
Expose padding prop for Popover component
​
**Why:**
When integrating the Popover feature, the **padding** prop has not been exposed from parent component, and thus would always fall to default value (**1rem**)... 

However, we now have use-cases where we need to remove this additional default padding - use no padding on Popover content.

e.g. (DropdownMenu)
<img width="234" alt="Screenshot 2022-07-21 at 13 31 48" src="https://user-images.githubusercontent.com/14894844/180203718-35f43cfd-0e2e-42cc-b0a3-4d0e6c9fa3ee.png">

**How:**
- exposed the padding prop on Popover component and kept default value of 1rem
- added example for Popover with no padding on the documentation page

- [x] Ready to merge