### PR TITLE
refactor: migrate first 5 components to SemanticColors

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { Colors } from '../../essentials';
+import { SemanticColors } from '../../essentials';
 import { Box } from '../Box/Box';
 import { Compact } from './components/Compact';
 import { DefaultPanel } from './components/Default';
@@ -9,7 +9,7 @@ import { AccordionProps } from './types';
 
 const HorizontalDivider = styled(Box)`
     border: 0;
-    border-top: solid 0.0625rem ${Colors.AUTHENTIC_BLUE_200};
+    border-top: solid 0.0625rem ${SemanticColors.border.primary};
 `;
 
 const HorizontalDividerTop = HorizontalDivider;

--- a/src/components/Accordion/components/ChevronDown.tsx
+++ b/src/components/Accordion/components/ChevronDown.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { ChevronDownIcon } from '../../../icons';
-import { Colors } from '../../../essentials';
+import { SemanticColors } from '../../../essentials';
 
 export const ChevronDown = styled(ChevronDownIcon)`
-    color: ${props => (props.color ? props.color : Colors.AUTHENTIC_BLUE_900)};
+    color: ${props => (props.color ? props.color : SemanticColors.icon.primary)};
 `;

--- a/src/components/Accordion/components/ChevronUp.tsx
+++ b/src/components/Accordion/components/ChevronUp.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { ChevronUpIcon } from '../../../icons';
-import { Colors } from '../../../essentials';
+import { SemanticColors } from '../../../essentials';
 
 export const ChevronUp = styled(ChevronUpIcon)`
-    color: ${props => (props.color ? props.color : Colors.AUTHENTIC_BLUE_900)};
+    color: ${props => (props.color ? props.color : SemanticColors.icon.primary)};
 `;

--- a/src/components/Accordion/components/Compact.tsx
+++ b/src/components/Accordion/components/Compact.tsx
@@ -1,7 +1,7 @@
 import React, { useState, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { Colors } from '../../../essentials';
+import { SemanticColors } from '../../../essentials';
 import { Box } from '../../Box/Box';
 import { Headline } from '../../Headline/Headline';
 import { Header } from './Header';
@@ -19,15 +19,15 @@ const StyleHeadline = styled(Headline)``;
 
 const PanelHeader = styled(Header)`
     &:hover ${StyleHeadline} {
-        color: ${Colors.ACTION_BLUE_1000};
+        color: ${SemanticColors.text.linkHover};
     }
 
     &:hover ${ChevronDown} {
-        color: ${Colors.ACTION_BLUE_1000};
+        color: ${SemanticColors.text.linkHover};
     }
 
     &:hover ${ChevronUp} {
-        color: ${Colors.ACTION_BLUE_1000};
+        color: ${SemanticColors.text.linkHover};
     }
 `;
 

--- a/src/components/Accordion/components/Default.tsx
+++ b/src/components/Accordion/components/Default.tsx
@@ -1,7 +1,7 @@
 import React, { useState, PropsWithChildren, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { Colors } from '../../../essentials';
+import { SemanticColors } from '../../../essentials';
 import { Text } from '../../Text/Text';
 import { Box } from '../../Box/Box';
 import { Headline } from '../../Headline/Headline';
@@ -12,47 +12,47 @@ import { Description } from './Description';
 import { AccordionProps } from '../types';
 
 const ButtonLabel = styled(Text).attrs({ as: 'p' })`
-    color: ${Colors.ACTION_BLUE_900};
+    color: ${SemanticColors.text.link};
 `;
 
 const PanelHeader = styled(Header)`
     &:hover {
-        background-color: ${Colors.ACTION_BLUE_50};
+        background-color: ${SemanticColors.background.info};
     }
 
     &:hover ${ButtonLabel} {
-        color: ${Colors.ACTION_BLUE_1000};
+        color: ${SemanticColors.text.linkHover};
     }
 
     &:hover ${ChevronDown} {
-        color: ${Colors.ACTION_BLUE_1000};
+        color: ${SemanticColors.text.linkHover};
     }
 `;
 
 const CardHeader = styled(Header).attrs({ p: '3' })`
-    background-color: ${Colors.AUTHENTIC_BLUE_50};
+    background-color: ${SemanticColors.background.secondary};
     border-radius: 0.3125rem 0.3125rem 0 0;
 
     &:hover {
-        background-color: ${Colors.ACTION_BLUE_50};
+        background-color: ${SemanticColors.background.info};
     }
 
     &:hover ${ButtonLabel} {
-        color: ${Colors.ACTION_BLUE_1000};
+        color: ${SemanticColors.text.linkHover};
     }
 
     &:hover ${ChevronUp} {
-        color: ${Colors.ACTION_BLUE_1000};
+        color: ${SemanticColors.text.linkHover};
     }
 `;
 
 const PanelBody = styled(Box).attrs({ my: '3' })`
-    border: solid 0.0625rem ${Colors.AUTHENTIC_BLUE_200};
+    border: solid 0.0625rem ${SemanticColors.border.primary};
     border-radius: 0.3125rem;
 `;
 
 const PanelIcon = ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <ChevronUp color={Colors.ACTION_BLUE_900} /> : <ChevronDown color={Colors.ACTION_BLUE_900} />;
+    isOpen ? <ChevronUp color={SemanticColors.icon.action} /> : <ChevronDown color={SemanticColors.icon.action} />;
 
 export const DefaultPanel = ({
     heading,

--- a/src/components/Accordion/components/Header.tsx
+++ b/src/components/Accordion/components/Header.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 
-import { Colors } from '../../../essentials';
+import { SemanticColors } from '../../../essentials';
 import { Box } from '../../Box/Box';
 
-export const Header = styled(Box).attrs({ p: '2', color: Colors.AUTHENTIC_BLUE_900 })`
+export const Header = styled(Box).attrs({ p: '2', color: SemanticColors.text.primary })`
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/src/components/Banner/Banner.spec.tsx
+++ b/src/components/Banner/Banner.spec.tsx
@@ -1,7 +1,7 @@
 import { render, waitForElementToBeRemoved, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import { Colors } from '../../essentials';
+import { SemanticColors } from '../../essentials';
 import { ANIMATION_DURATION, Banner, useBannerDismiss } from './Banner';
 
 describe('Banner', () => {
@@ -106,19 +106,19 @@ describe('Banner', () => {
     describe('renders the variant', () => {
         it('"info" correctly', () => {
             expect(render(<Banner variant="info" />).container.firstChild).toHaveStyle(`
-                background-color: ${Colors.AUTHENTIC_BLUE_550};
+                background-color: ${SemanticColors.background.secondaryEmphasized};
             `);
         });
 
         it('"success" correctly', () => {
             expect(render(<Banner variant="success" />).container.firstChild).toHaveStyle(`
-                background-color: ${Colors.POSITIVE_GREEN_900};
+                background-color: ${SemanticColors.background.successEmphasized};
             `);
         });
 
         it('"danger" correctly', () => {
             expect(render(<Banner variant="danger" />).container.firstChild).toHaveStyle(`
-                background-color: ${Colors.NEGATIVE_ORANGE_900};
+                background-color: ${SemanticColors.background.dangerEmphasized};
             `);
         });
     });

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useState, useContext } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import styled, { css } from 'styled-components';
 import { variant } from 'styled-system';
-import { Colors, Elevation } from '../../essentials';
+import { Elevation, SemanticColors } from '../../essentials';
 import { theme } from '../../essentials/theme';
 import { get } from '../../utils/themeGet';
 
@@ -60,13 +60,13 @@ const riseUp = css`
 const bannerVariants = variant({
     variants: {
         info: {
-            backgroundColor: Colors.AUTHENTIC_BLUE_550
+            backgroundColor: SemanticColors.background.secondaryEmphasized
         },
         success: {
-            backgroundColor: Colors.POSITIVE_GREEN_900
+            backgroundColor: SemanticColors.background.successEmphasized
         },
         danger: {
-            backgroundColor: Colors.NEGATIVE_ORANGE_900
+            backgroundColor: SemanticColors.background.dangerEmphasized
         }
     }
 });
@@ -114,7 +114,7 @@ const AnimatedBanner = styled.div.attrs({ theme })<BannerProps>`
     overflow: auto;
     box-sizing: border-box;
     padding: ${get('space.3')};
-    background-color: ${Colors.AUTHENTIC_BLUE_550};
+    background-color: ${SemanticColors.background.secondaryEmphasized};
 
     position: fixed;
     left: 0;

--- a/src/components/Box/Box.spec.tsx
+++ b/src/components/Box/Box.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
-import { Colors } from '../../essentials';
+import { SemanticColors } from '../../essentials';
 import { Box } from './Box';
 
 describe('Box', () => {
@@ -21,7 +21,9 @@ describe('Box', () => {
     });
 
     it('renders color', () => {
-        expect(render(<Box backgroundColor={Colors.POSITIVE_GREEN_900} />).container.firstChild).toMatchSnapshot();
+        expect(
+            render(<Box backgroundColor={SemanticColors.background.successEmphasized} />).container.firstChild
+        ).toMatchSnapshot();
     });
 
     it('renders flexbox', () => {
@@ -36,7 +38,7 @@ describe('Box', () => {
 
     it('accepts props spreading', () => {
         const renderBox = () => {
-            const props = { backgroundColor: Colors.POSITIVE_GREEN_900 };
+            const props = { backgroundColor: SemanticColors.background.successEmphasized };
             return <Box {...props} />;
         };
         expect(renderBox).not.toThrow();

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Button } from './Button';
-import { Colors } from '../../essentials';
+import { SemanticColors } from '../../essentials';
 
 describe('standard button', () => {
     it('renders by default the primary variant', () => {
@@ -15,8 +15,8 @@ describe('standard button', () => {
         it('renders as design system suggests', () => {
             const { container } = render(<Button variant="primary">Click</Button>);
             expect(container.firstChild).toHaveStyle(`
-              background: ${Colors.AUTHENTIC_BLUE_900};
-              color: ${Colors.WHITE};
+              background: ${SemanticColors.button.primary.background};
+              color: ${SemanticColors.button.primary.text};
             `);
             expect(container.firstChild).toMatchSnapshot();
         });
@@ -26,9 +26,9 @@ describe('standard button', () => {
         it('renders as design system suggests', () => {
             const { container } = render(<Button variant="secondary">Click</Button>);
             expect(container.firstChild).toHaveStyle(`
-              background: ${Colors.WHITE};
-              color: ${Colors.AUTHENTIC_BLUE_900};
-              border-color: ${Colors.AUTHENTIC_BLUE_200};
+              background: ${SemanticColors.button.secondary.background};
+              color: ${SemanticColors.button.secondary.text};
+              border-color: ${SemanticColors.button.secondary.border};
             `);
             expect(container.firstChild).toMatchSnapshot();
         });
@@ -38,8 +38,8 @@ describe('standard button', () => {
         it('renders as design system suggests', () => {
             const { container } = render(<Button variant="danger">Click</Button>);
             expect(container.firstChild).toHaveStyle(`
-              background: ${Colors.NEGATIVE_ORANGE_900};
-              color: ${Colors.WHITE};
+              background: ${SemanticColors.button.danger.background};
+              color: ${SemanticColors.button.danger.text};
             `);
             expect(container.firstChild).toMatchSnapshot();
         });
@@ -66,8 +66,8 @@ describe('inverted button', () => {
                 </Button>
             );
             expect(container.firstChild).toHaveStyle(`
-              background: ${Colors.WHITE};
-              color: ${Colors.ACTION_BLUE_900};
+              background: ${SemanticColors.button.primary.backgroundInverted};
+              color: ${SemanticColors.button.primary.textInverted};
             `);
             expect(container.firstChild).toMatchSnapshot();
         });
@@ -83,8 +83,8 @@ describe('inverted button', () => {
 
             expect(container.firstChild).toHaveStyle(`
               background: transparent;
-              color: ${Colors.WHITE};
-              border-color: ${Colors.WHITE};
+              color: ${SemanticColors.button.secondary.textInverted};
+              border-color: ${SemanticColors.button.secondary.borderInverted};
             `);
             expect(container.firstChild).toMatchSnapshot();
         });

--- a/src/components/Toggle/Slide.tsx
+++ b/src/components/Toggle/Slide.tsx
@@ -1,16 +1,16 @@
 import styled from 'styled-components';
-import { Colors } from '../../essentials';
+import { SemanticColors } from '../../essentials';
 
 const determineBackground = (props: SlideProps) => {
     if (props.disabled) {
-        return Colors.AUTHENTIC_BLUE_50;
+        return SemanticColors.background.secondary;
     }
 
     if (props.error) {
-        return Colors.NEGATIVE_ORANGE_900;
+        return SemanticColors.background.dangerEmphasized;
     }
 
-    return Colors.ACTION_BLUE_900;
+    return SemanticColors.background.infoEmphasized;
 };
 
 interface SlideProps {
@@ -23,7 +23,10 @@ const Slide = styled.div<SlideProps>`
     height: 1rem;
 
     cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-    background: ${props => (props.disabled ? Colors.AUTHENTIC_BLUE_50 : Colors.AUTHENTIC_BLUE_200)};
+    background: ${props =>
+        props.disabled
+            ? SemanticColors.background.secondary
+            : SemanticColors.border.primary}; // TODO should this come from background
     display: inline-block;
     border-radius: 0.5rem;
     position: relative;
@@ -36,7 +39,8 @@ const Slide = styled.div<SlideProps>`
         left: 0;
         width: 1.25rem;
         height: 1.25rem;
-        background: ${props => (props.disabled ? Colors.AUTHENTIC_BLUE_50 : Colors.WHITE)};
+        background: ${props =>
+            props.disabled ? SemanticColors.background.secondary : SemanticColors.background.primary};
         border-radius: 50%;
         box-shadow: 0 0 0.0625rem 0 rgba(0, 0, 0, 0.05), 0 0.0625rem 0.1875rem 0 rgba(0, 0, 0, 0.4);
         transform: translateX(0);

--- a/src/components/Toggle/Slide.tsx
+++ b/src/components/Toggle/Slide.tsx
@@ -18,15 +18,13 @@ interface SlideProps {
     error?: boolean;
 }
 
+// TODO use SemanticColors.forms once https://github.com/freenowtech/wave/issues/286 is done
 const Slide = styled.div<SlideProps>`
     width: 2.25rem;
     height: 1rem;
 
     cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-    background: ${props =>
-        props.disabled
-            ? SemanticColors.background.secondary
-            : SemanticColors.border.primary}; // TODO should this come from background
+    background: ${props => (props.disabled ? SemanticColors.background.secondary : SemanticColors.border.primary)};
     display: inline-block;
     border-radius: 0.5rem;
     position: relative;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -4,7 +4,7 @@ import styled, { keyframes } from 'styled-components';
 import { usePopper } from 'react-popper';
 import { Placement } from '@popperjs/core/lib/enums';
 import { variant } from 'styled-system';
-import { Colors, MediaQueries } from '../../essentials';
+import { MediaQueries, SemanticColors } from '../../essentials';
 import { get } from '../../utils/themeGet';
 import { Text } from '../Text/Text';
 import { mapPlacementWithDeprecationWarning, TooltipPlacement } from './TooltipPlacement';
@@ -87,7 +87,8 @@ interface TooltipBodyProps {
 
 const TooltipBody = styled.div<TooltipBodyProps>`
     position: relative;
-    background-color: ${p => (p.inverted ? Colors.AUTHENTIC_BLUE_50 : Colors.AUTHENTIC_BLUE_900)};
+    background-color: ${p =>
+        p.inverted ? SemanticColors.background.secondary : SemanticColors.background.primaryEmphasized};
     padding: 0.25rem 0.5rem;
     border-radius: ${get('radii.2')};
     opacity: 0;
@@ -110,7 +111,8 @@ const TooltipBody = styled.div<TooltipBodyProps>`
         position: absolute;
         pointer-events: none;
         border: 0.25rem solid rgba(0, 0, 0, 0);
-        border-bottom-color: ${p => (p.inverted ? Colors.AUTHENTIC_BLUE_50 : Colors.AUTHENTIC_BLUE_900)};
+        border-bottom-color: ${p =>
+            p.inverted ? SemanticColors.background.secondary : SemanticColors.background.primaryEmphasized};
         margin-left: -0.25rem;
 
         ${arrowPlacementStyles}
@@ -149,7 +151,6 @@ const Tooltip: React.FC<TooltipProps> = ({
      */
     const [triggerReference, setTriggerReference] = React.useState(undefined);
     const [contentReference, setContentReference] = React.useState(undefined);
-
 
     /**
      * Map the older placement values to Popper placement  as we need to get the correct placement for the tooltip from the Popper library

--- a/src/essentials/index.ts
+++ b/src/essentials/index.ts
@@ -1,4 +1,4 @@
-export { Colors } from './Colors/Colors';
+export { Colors, SemanticColors } from './Colors/Colors';
 export { Elevation } from './Elevation/Elevation';
 export { Spaces } from './Spaces/Spaces';
 export { Breakpoints, MediaQueries } from './Breakpoints/Breakpoints';


### PR DESCRIPTION
**What:**

Start migrating components to use semantic colors.

​
**Why:**

Part of #203 

​
**How:**

Use `SemanticColors` instead of `Colors`in:
- Accordion
- Banner
- Box
- Button
- Toggle
- Tooltip

- [x] Ready to be merged
- [x] Need design input in one TODO
