### PR TITLE
fix(password): use `flex-end` instead of `end`

### DIFF
--- a/src/components/Password/ToggleButton.ts
+++ b/src/components/Password/ToggleButton.ts
@@ -28,7 +28,7 @@ const ToggleButton = styled.button<Pick<InputProps, 'size' | 'variant'>>`
     height: 100%;
     width: ${TOGGLE_MODE_BUTTON_WIDTH};
     right: 0;
-    align-items: ${p => (p.size === 'small' || p.variant === 'bottom-lined' ? 'end' : 'center')};
+    align-items: ${p => (p.size === 'small' || p.variant === 'bottom-lined' ? 'flex-end' : 'center')};
     padding-bottom: ${p => {
         if (p.size === 'small') return '0.25rem';
 


### PR DESCRIPTION
Some browsers lack support for `end` value for `align-items` css prop.

This would make the icon in ToggleButton to be misplaced.

More specifically:
https://caniuse.com/mdn-css_properties_align-items_flex_context_start_end

Close issue #290

​
**Media:**

Before:
<img width="1039" alt="Screenshot 2022-10-25 at 17 16 31" src="https://user-images.githubusercontent.com/539801/197814489-8b464531-829b-45a8-8af9-64e48b7f67e8.png">

After:
<img width="1011" alt="Screenshot 2022-10-25 at 18 24 41" src="https://user-images.githubusercontent.com/539801/197829902-aab1efc0-b826-4686-855e-2deb45d74cc6.png">


**Checklist:**

-   [ ] Ready to be merged
