### PR TITLE
Feat/keep action button file picker

### DIFF
--- a/src/components/FilePicker/FilePicker.tsx
+++ b/src/components/FilePicker/FilePicker.tsx
@@ -38,7 +38,7 @@ interface FilePickerProps extends MarginProps, ComponentPropsWithoutRef<'input'>
     /**
      * Keep the action button displayed instead of showing the success state.
      */
-    keepActionButton?: boolean;
+    alwaysShowActionButton?: boolean;
     /**
      * Whether or not the component should render an error state
      */
@@ -138,7 +138,7 @@ const FilePicker: FC<FilePickerProps> = ({
     onFileChange = () => undefined,
     onChange = () => undefined,
     disabled = false,
-    keepActionButton = false,
+    alwaysShowActionButton = false,
     ...nonInputProps
 }: FilePickerProps) => {
     const inputEl = useRef<HTMLInputElement>(null);
@@ -195,7 +195,7 @@ const FilePicker: FC<FilePickerProps> = ({
                     </Text>
                 </Box>
                 <Box display={{ _: 'none', medium: 'flex' }} alignItems="center" justifyContent="top">
-                    {!keepActionButton && validFileSelected ? (
+                    {!alwaysShowActionButton && validFileSelected ? (
                         <CheckCircleOutlineIcon color={ICON_FILE_FEEDBACK_COLOR} />
                     ) : (
                         <InputButton variant="secondary" type="button" tabIndex={-1} onClick={onClickHandler}>
@@ -206,7 +206,7 @@ const FilePicker: FC<FilePickerProps> = ({
                 <Box display={{ _: 'flex', medium: 'none' }} alignItems="top">
                     {validFileSelected ? <CheckCircleOutlineIcon color={ICON_FILE_FEEDBACK_COLOR} /> : <ShareIcon />}
                 </Box>
-            </Outliner>
+            </Outliner> 
         </Box>
     );
 };

--- a/src/components/FilePicker/FilePicker.tsx
+++ b/src/components/FilePicker/FilePicker.tsx
@@ -38,7 +38,7 @@ interface FilePickerProps extends MarginProps, ComponentPropsWithoutRef<'input'>
     /**
      * Keep the action button displayed instead of showing the success state.
      */
-    keepActionButton: boolean;
+    keepActionButton?: boolean;
     /**
      * Whether or not the component should render an error state
      */

--- a/src/components/FilePicker/FilePicker.tsx
+++ b/src/components/FilePicker/FilePicker.tsx
@@ -36,6 +36,10 @@ interface FilePickerProps extends MarginProps, ComponentPropsWithoutRef<'input'>
      */
     buttonText: string;
     /**
+     * Keep the action button displayed instead of showing the success state.
+     */
+    keepActionButton: boolean;
+    /**
      * Whether or not the component should render an error state
      */
     error?: boolean;
@@ -134,6 +138,7 @@ const FilePicker: FC<FilePickerProps> = ({
     onFileChange = () => undefined,
     onChange = () => undefined,
     disabled = false,
+    keepActionButton = false,
     ...nonInputProps
 }: FilePickerProps) => {
     const inputEl = useRef<HTMLInputElement>(null);
@@ -190,7 +195,7 @@ const FilePicker: FC<FilePickerProps> = ({
                     </Text>
                 </Box>
                 <Box display={{ _: 'none', medium: 'flex' }} alignItems="center" justifyContent="top">
-                    {validFileSelected ? (
+                    {!keepActionButton && validFileSelected ? (
                         <CheckCircleOutlineIcon color={ICON_FILE_FEEDBACK_COLOR} />
                     ) : (
                         <InputButton variant="secondary" type="button" tabIndex={-1} onClick={onClickHandler}>

--- a/src/components/FilePicker/docs/FilePicker.mdx
+++ b/src/components/FilePicker/docs/FilePicker.mdx
@@ -67,6 +67,7 @@ The example below will demostrate how to create compositions of `FilePicker`
       name="logo"
       onChange={(e) => console.log('onChange', e)}
       onFileChange={(file, e) => console.log('onFileChange', file, e)}
+      keepActionButton={true}
       mt={1}
     />
     <FilePicker

--- a/src/components/FilePicker/docs/FilePicker.mdx
+++ b/src/components/FilePicker/docs/FilePicker.mdx
@@ -67,7 +67,7 @@ The example below will demostrate how to create compositions of `FilePicker`
       name="logo"
       onChange={(e) => console.log('onChange', e)}
       onFileChange={(file, e) => console.log('onFileChange', file, e)}
-      keepActionButton={true}
+      alwaysShowActionButton
       mt={1}
     />
     <FilePicker

--- a/src/components/FilePicker/docs/FilePickerPropsTable.tsx
+++ b/src/components/FilePicker/docs/FilePickerPropsTable.tsx
@@ -31,6 +31,13 @@ export const FilePickerPropsTable: FC = () => {
                 'Text to display within component button, it describes the main action, it works better when short.'
         },
         {
+            name: 'keepActionButton',
+            type: 'boolean',
+            description:
+                'Keep the action button displayed instead of showing the success state.',
+            defaultValue: 'false'
+        },
+        {
             name: 'error',
             type: 'boolean',
             description: 'Whether or not the component should render an error state.'

--- a/src/components/FilePicker/docs/FilePickerPropsTable.tsx
+++ b/src/components/FilePicker/docs/FilePickerPropsTable.tsx
@@ -31,7 +31,7 @@ export const FilePickerPropsTable: FC = () => {
                 'Text to display within component button, it describes the main action, it works better when short.'
         },
         {
-            name: 'keepActionButton',
+            name: 'alwaysShowActionButton',
             type: 'boolean',
             description:
                 'Keep the action button displayed instead of showing the success state.',


### PR DESCRIPTION
**What:**
Extend the `FilePicker` to keep displaying the action button after choosing a file

​
**Why:**
We want to make it more evident that the user can click again to upload another file

​
**How:**
Added a new boolean prop `keepAcionButton` and modify the success icon / action button toggle
​
**Media:**
<img width="521" alt="Screenshot 2023-02-14 at 10 13 21" src="https://user-images.githubusercontent.com/12762609/218701020-6e4cafc2-2c34-4902-94be-fe660cfbfc63.png">

** Checklist **
-   [x] Ready to merge? Need to fix falling tests before
