### PR TITLE
Wech 28/remove nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
                 "@types/react-select": "^4.0.18",
                 "@types/styled-system": "^5.1.9",
                 "date-fns": "^2.11.1",
-                "nanoid": "^3.1.23",
                 "react-popper": "^2.3.0",
                 "react-tether": "^2.0.7",
                 "react-transition-group": "^4.3.0",
@@ -10763,12 +10762,6 @@
                 "node": ">= 8.3"
             }
         },
-        "node_modules/@types/jest/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
-        },
         "node_modules/@types/jscodeshift": {
             "version": "0.11.6",
             "resolved": "https://registry.npmjs.org/@types/jscodeshift/-/jscodeshift-0.11.6.tgz",
@@ -19744,11 +19737,6 @@
                 "react-is": "^16.7.0"
             }
         },
-        "node_modules/hoist-non-react-statics/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
         "node_modules/hook-std": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
@@ -21914,12 +21902,6 @@
             "engines": {
                 "node": ">= 8.3"
             }
-        },
-        "node_modules/jest-diff/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
         },
         "node_modules/jest-diff/node_modules/supports-color": {
             "version": "7.2.0",
@@ -25934,6 +25916,7 @@
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
             "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -30668,11 +30651,6 @@
                 "react-is": "^16.13.1"
             }
         },
-        "node_modules/prop-types/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
         "node_modules/property-information": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
@@ -31046,8 +31024,7 @@
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "node_modules/react-lottie": {
             "version": "1.2.3",
@@ -43519,7 +43496,7 @@
                 "lodash": "^4.17.21",
                 "prop-types": "^15.7.2",
                 "react-element-to-jsx-string": "^14.3.4",
-                "react-refresh": "^0.11.0",
+                "react-refresh": "0.11.0",
                 "read-pkg-up": "^7.0.1",
                 "regenerator-runtime": "^0.13.7",
                 "ts-dedent": "^2.0.0",
@@ -44594,7 +44571,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -44925,14 +44902,8 @@
                         "@jest/types": "^25.5.0",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
+                        "react-is": "17.0.2"
                     }
-                },
-                "react-is": {
-                    "version": "16.13.1",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-                    "dev": true
                 }
             }
         },
@@ -51982,14 +51953,7 @@
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "requires": {
-                "react-is": "^16.7.0"
-            },
-            "dependencies": {
-                "react-is": {
-                    "version": "16.13.1",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-                }
+                "react-is": "17.0.2"
             }
         },
         "hook-std": {
@@ -53489,7 +53453,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -53570,14 +53534,8 @@
                         "@jest/types": "^25.5.0",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
+                        "react-is": "17.0.2"
                     }
-                },
-                "react-is": {
-                    "version": "16.13.1",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-                    "dev": true
                 },
                 "supports-color": {
                     "version": "7.2.0",
@@ -53689,7 +53647,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -54076,7 +54034,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -54177,7 +54135,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -54298,7 +54256,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -54400,7 +54358,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -55029,7 +54987,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "semver": {
@@ -55245,7 +55203,7 @@
                         "@jest/types": "^26.6.2",
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
-                        "react-is": "^17.0.1"
+                        "react-is": "17.0.2"
                     }
                 },
                 "supports-color": {
@@ -56726,7 +56684,8 @@
         "nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -60114,7 +60073,7 @@
             "requires": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
+                "react-is": "17.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -60254,14 +60213,7 @@
             "requires": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-            },
-            "dependencies": {
-                "react-is": {
-                    "version": "16.13.1",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-                }
+                "react-is": "17.0.2"
             }
         },
         "property-information": {
@@ -60558,8 +60510,7 @@
         "react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "react-lottie": {
             "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
     "main": "lib/cjs/index.js",
     "typings": "lib/types/index.d.ts",
     "module": "lib/esm/index.js",
-    "sideEffects": [
-        "lib/esm/polyfills.js",
-        "lib/cjs/polyfills.js"
-    ],
     "scripts": {
         "clean": "rm -rf lib",
         "build": "npm run clean && npm run build:cjs && npm run build:esm",
@@ -137,7 +133,6 @@
         "@types/react-select": "^4.0.18",
         "@types/styled-system": "^5.1.9",
         "date-fns": "^2.11.1",
-        "nanoid": "^3.1.23",
         "react-popper": "^2.3.0",
         "react-tether": "^2.0.7",
         "react-transition-group": "^4.3.0",

--- a/src/components/Datepicker/Month.tsx
+++ b/src/components/Datepicker/Month.tsx
@@ -61,8 +61,9 @@ const Month: FC<MonthProps> = ({ year, month, firstDayOfWeek, locale }: MonthPro
                         return <Day date={day.date} key={day.date.toString()} dayLabel={day.dayLabel} />;
                     }
 
+                    // we can use index as a key since the array is never reordered
                     // eslint-disable-next-line react/no-array-index-key
-                    return <div key={index} />; // we can use index as a key since the array is never reordered
+                    return <div key={index} />;
                 })}
             </DaysContainer>
         </div>

--- a/src/components/Datepicker/Month.tsx
+++ b/src/components/Datepicker/Month.tsx
@@ -3,7 +3,6 @@ import { useMonth, FirstDayOfWeek } from '@datepicker-react/hooks';
 import styled from 'styled-components';
 import { format } from 'date-fns';
 
-import { generateId } from '../../utils/ids';
 import { Colors } from '../../essentials';
 import { Text } from '../Text/Text';
 import { Day } from './Day';
@@ -57,12 +56,13 @@ const Month: FC<MonthProps> = ({ year, month, firstDayOfWeek, locale }: MonthPro
                 ))}
             </Weekdays>
             <DaysContainer>
-                {days.map(day => {
+                {days.map((day, index) => {
                     if (typeof day === 'object') {
                         return <Day date={day.date} key={day.date.toString()} dayLabel={day.dayLabel} />;
                     }
 
-                    return <div key={generateId()} />;
+                    // eslint-disable-next-line react/no-array-index-key
+                    return <div key={index} />; // we can use index as a key since the array is never reordered
                 })}
             </DaysContainer>
         </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import './polyfills';
-
 export * from './components';
 export * from './essentials';
 export * from './icons';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,8 +1,0 @@
-import { isSSR } from './utils/isSSR';
-
-// create an alias for the crypto api for IE11 (required by `nanoid`)
-if (!isSSR() && !window.crypto) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    window.crypto = window.msCrypto;
-}

--- a/src/utils/__mocks__/ids.ts
+++ b/src/utils/__mocks__/ids.ts
@@ -1,1 +1,0 @@
-export const generateId = (): string => 'random';

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,3 +1,0 @@
-import { nanoid } from 'nanoid';
-
-export const generateId = (): string => `wave-${nanoid(6)}`;


### PR DESCRIPTION
**What:**

Remove remaining use of `nanoid` in the project.

​
**Why:**

To get rid of the dependency.

​
**How:**

- Stop using `generateId` in `Month.tsx`
- Delete the `generateId` util (`ids.ts`)
- Delete `ids.ts` mock
- Delete `polyfills.ts` file, which was used only for `nanoid`

​
**Checklist:**

-   [x] Ready to be merged

Part of #311 
Closes #240 
