### PR TITLE
fix: set focus on password input resolve #124

### DIFF
--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -96,6 +96,7 @@ const Password = forwardRef<HTMLDivElement, PasswordProps>(
                             onClick={() => {
                                 setIsHidden(prevValue => !prevValue);
 
+// TODO use ref passed to the input once https://github.com/freenowtech/wave/issues/169 is solved
                                 // set input focus
                                 const inputElement = document.querySelector(`input[id=${inputId}]`);
                                 if (inputElement) {

--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -98,7 +98,7 @@ const Password = forwardRef<HTMLDivElement, PasswordProps>(
 
 // TODO use ref passed to the input once https://github.com/freenowtech/wave/issues/169 is solved
                                 // set input focus
-                                const inputElement = document.querySelector(`input[id=${inputId}]`);
+                                const inputElement: HTMLElement = document.querySelector(`input[id=${inputId}]`);
                                 if (inputElement) {
                                     inputElement.focus();
                                 }

--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -95,6 +95,12 @@ const Password = forwardRef<HTMLDivElement, PasswordProps>(
                             type="button"
                             onClick={() => {
                                 setIsHidden(prevValue => !prevValue);
+
+                                // set input focus
+                                const inputElement = document.querySelector(`input[id=${inputId}]`);
+                                if (inputElement) {
+                                    inputElement.focus();
+                                }
                             }}
                             aria-controls={inputId}
                             aria-label={isHidden ? aria.showPasswordButton : aria.hidePasswordButton}


### PR DESCRIPTION
**What:**

Fixed set focus on password input while use click on eye button.

​
**Why:**

Improving the user experience, Closes #124 

​
**How:**

Added the focus based on input id.

​
**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
