### PR TITLE
feat: implement compound component approach for InfoBanner

### DIFF
--- a/src/components/InfoBanner/InfoBanner.tsx
+++ b/src/components/InfoBanner/InfoBanner.tsx
@@ -23,7 +23,7 @@ interface InfoBannerProps extends BoxProps {
     linkUrl?: string;
 }
 
-export type InfoBannerVariants = 'info' | 'success' | 'warning' | 'error';
+type InfoBannerVariants = 'info' | 'success' | 'warning' | 'error';
 
 interface BoxWithVariant extends BoxProps {
     variant: InfoBannerVariants;

--- a/src/components/InfoBanner/InfoBanner.tsx
+++ b/src/components/InfoBanner/InfoBanner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { variant as styledVariant } from 'styled-system';
 import { get } from '../../utils/themeGet';
+import { theme } from '../../essentials/theme';
 import {
     CheckCircleSolidIcon,
     CloseCircleSolidIcon,
@@ -12,7 +13,8 @@ import {
 import { BoxProps, Box } from '../Box/Box';
 import { Link } from '../Link/Link';
 import { Text } from '../Text/Text';
-import { Colors, Spaces } from '../../essentials';
+import { Headline } from '../Headline/Headline';
+import { Spaces } from '../../essentials';
 
 interface InfoBannerProps extends BoxProps {
     title: string;
@@ -106,7 +108,7 @@ const emphasizedIconColorVariants = styledVariant({
     }
 });
 
-export const RoundedBox = styled(Box)<BoxWithVariant>`
+export const RoundedBox = styled(Box).attrs({ theme })<BoxWithVariant>`
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
@@ -115,25 +117,18 @@ export const RoundedBox = styled(Box)<BoxWithVariant>`
     padding: ${`${Spaces[1]} ${Spaces[2]} ${Spaces[1]} ${Spaces[1]}`};
     ${({ emphasized }) => (emphasized ? emphasizedBannerVariants : bannerVariants)};
 
-    .Infobanner__Title,
-    .Infobanner__Description {
-        color: ${({ emphasized, variant }) =>
-            emphasized && variant !== 'warning' ? 'white' : Colors.AUTHENTIC_BLUE_900};
-    }
-
-    .Infobanner__Link {
-        &:link,
-        &:visited {
-            color: ${({ emphasized, variant }) =>
-                emphasized && variant !== 'warning' ? 'white' : Colors.ACTION_BLUE_900};
-        }
-
-        &:hover,
-        &:active {
-            color: ${({ emphasized, variant }) =>
-                emphasized && variant !== 'warning' ? Colors.AUTHENTIC_BLUE_350 : Colors.ACTION_BLUE_1000};
-        }
-    }
+    --info-banner-text-color: ${({ emphasized, variant }) =>
+        emphasized && variant !== 'warning'
+            ? get('semanticColors.text.primaryInverted')
+            : get('semanticColors.text.primary')};
+    --info-banner-link-color: ${({ emphasized, variant }) =>
+        emphasized && variant !== 'warning'
+            ? get('semanticColors.text.primaryInverted')
+            : get('semanticColors.text.link')};
+    --info-banner-link-hover-color: ${({ emphasized, variant }) =>
+        emphasized && variant !== 'warning'
+            ? get('semanticColors.text.tertiary')
+            : get('semanticColors.text.linkHover')};
 `;
 
 export const IconBox = styled(Box)<BoxWithVariant>`
@@ -176,9 +171,9 @@ const InfoBanner = ({
                 <BannerIcon size={20} color="inherit" />
             </IconBox>
             <Box display="flex" flexDirection="column">
-                <Text fontWeight="bold" textAlign="left" inverted={isInverted}>
+                <Headline as="h4" textAlign="left" inverted={isInverted}>
                     {title}
-                </Text>
+                </Headline>
                 <Text fontSize="small" textAlign="left" inverted={isInverted}>
                     {description}
                 </Text>

--- a/src/components/InfoBanner/InfoBanner.tsx
+++ b/src/components/InfoBanner/InfoBanner.tsx
@@ -12,7 +12,7 @@ import {
 import { BoxProps, Box } from '../Box/Box';
 import { Link } from '../Link/Link';
 import { Text } from '../Text/Text';
-import { Spaces } from '../../essentials';
+import { Colors, Spaces } from '../../essentials';
 
 interface InfoBannerProps extends BoxProps {
     title: string;
@@ -23,7 +23,7 @@ interface InfoBannerProps extends BoxProps {
     linkUrl?: string;
 }
 
-type InfoBannerVariants = 'info' | 'success' | 'warning' | 'error';
+export type InfoBannerVariants = 'info' | 'success' | 'warning' | 'error';
 
 interface BoxWithVariant extends BoxProps {
     variant: InfoBannerVariants;
@@ -106,7 +106,7 @@ const emphasizedIconColorVariants = styledVariant({
     }
 });
 
-const RoundedBox = styled(Box)<BoxWithVariant>`
+export const RoundedBox = styled(Box)<BoxWithVariant>`
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
@@ -114,13 +114,33 @@ const RoundedBox = styled(Box)<BoxWithVariant>`
     border: 0.0625rem solid;
     padding: ${`${Spaces[1]} ${Spaces[2]} ${Spaces[1]} ${Spaces[1]}`};
     ${({ emphasized }) => (emphasized ? emphasizedBannerVariants : bannerVariants)};
+
+    .Infobanner__Title,
+    .Infobanner__Description {
+        color: ${({ emphasized, variant }) =>
+            emphasized && variant !== 'warning' ? 'white' : Colors.AUTHENTIC_BLUE_900};
+    }
+
+    .Infobanner__Link {
+        &:link,
+        &:visited {
+            color: ${({ emphasized, variant }) =>
+                emphasized && variant !== 'warning' ? 'white' : Colors.ACTION_BLUE_900};
+        }
+
+        &:hover,
+        &:active {
+            color: ${({ emphasized, variant }) =>
+                emphasized && variant !== 'warning' ? Colors.AUTHENTIC_BLUE_350 : Colors.ACTION_BLUE_1000};
+        }
+    }
 `;
 
-const IconBox = styled(Box)<BoxWithVariant>`
+export const IconBox = styled(Box)<BoxWithVariant>`
     ${({ emphasized }) => (emphasized ? emphasizedIconColorVariants : iconColorVariants)};
 `;
 
-const ICON_VARIANTS: {
+export const ICON_VARIANTS: {
     [key in InfoBannerVariants]: React.FC<IconProps>;
 } = {
     warning: WarningSolidIcon,
@@ -129,7 +149,7 @@ const ICON_VARIANTS: {
     error: CloseCircleSolidIcon
 };
 
-const ROLE_VARIANTS: {
+export const ROLE_VARIANTS: {
     [key in InfoBannerVariants]: string;
 } = {
     error: 'alert',

--- a/src/components/InfoBanner/blocks/InfoBannerCard.tsx
+++ b/src/components/InfoBanner/blocks/InfoBannerCard.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { BoxProps, Box } from '../../Box/Box';
+import { Headline } from '../../Headline/Headline';
 import { Link as WaveLink } from '../../Link/Link';
 import { Text } from '../../Text/Text';
 
@@ -13,32 +14,32 @@ interface CardProps extends BoxProps {
     emphasized?: boolean;
 }
 
-const LinkList = styled.ul`
-    margin-block-start: 0.3rem;
-    margin-block-end: 0.3rem;
-    padding-inline-start: 1.5rem;
+const StyledTitle = styled(Headline).attrs({ as: 'h4', textAlign: 'left' })`
+    color: var(--info-banner-text-color);
+`;
 
-    li {
-        line-height: 1.1;
+const StyledDescription = styled(Text).attrs({ fontSize: 'small', textAlign: 'left' })`
+    color: var(--info-banner-text-color);
+`;
+
+const StyledLink = styled(WaveLink).attrs({ fontSize: 0, textAlign: 'left', target: '_blank', marginTop: '0.25rem' })`
+    &:link,
+    &:visited {
+        color: var(--info-banner-link-color);
+    }
+
+    &:hover,
+    &:active {
+        color: var(--info-banner-link-hover-color);
     }
 `;
 
-const Title = ({ children }: { children: string }) => (
-    <Text className="Infobanner__Title" fontWeight="bold" textAlign="left">
-        {children}
-    </Text>
-);
+const Title = ({ children }: { children: string }) => <StyledTitle>{children}</StyledTitle>;
 
-const Description = ({ children }: { children: string }) => (
-    <Text className="Infobanner__Description" fontSize="small" textAlign="left">
-        {children}
-    </Text>
-);
+const Description = ({ children }: { children: string }) => <StyledDescription>{children}</StyledDescription>;
 
 const Link = ({ linkUrl, linkText }: { linkUrl: string; linkText: string }) => (
-    <WaveLink className="Infobanner__Link" fontSize="0" textAlign="left" href={linkUrl} target="_blank" mt="0.25rem">
-        {linkText}
-    </WaveLink>
+    <StyledLink href={linkUrl}>{linkText}</StyledLink>
 );
 
 // TODO: Document this compound component properly when Storybook migration is complete
@@ -60,6 +61,5 @@ const InfoBannerCard = ({ children, variant = 'info', emphasized, ...props }: Ca
 InfoBannerCard.Title = Title;
 InfoBannerCard.Description = Description;
 InfoBannerCard.Link = Link;
-InfoBannerCard.LinkList = LinkList;
 
 export { InfoBannerCard };

--- a/src/components/InfoBanner/blocks/InfoBannerCard.tsx
+++ b/src/components/InfoBanner/blocks/InfoBannerCard.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+
+import { BoxProps, Box } from '../../Box/Box';
+import { Link as WaveLink } from '../../Link/Link';
+import { Text } from '../../Text/Text';
+
+import { ICON_VARIANTS, IconBox, InfoBannerVariants, ROLE_VARIANTS, RoundedBox } from '../InfoBanner';
+
+interface CardProps extends BoxProps {
+    children: ReactNode;
+    variant?: InfoBannerVariants;
+    emphasized?: boolean;
+}
+
+const LinkList = styled.ul`
+    margin-block-start: 0.3rem;
+    margin-block-end: 0.3rem;
+    padding-inline-start: 1.5rem;
+
+    li {
+        line-height: 1.1;
+    }
+`;
+
+const Title = ({ children }: { children: string }) => (
+    <Text className="Infobanner__Title" fontWeight="bold" textAlign="left">
+        {children}
+    </Text>
+);
+
+const Description = ({ children }: { children: string }) => (
+    <Text className="Infobanner__Description" fontSize="small" textAlign="left">
+        {children}
+    </Text>
+);
+
+const Link = ({ linkUrl, linkText }: { linkUrl: string; linkText: string }) => (
+    <WaveLink className="Infobanner__Link" fontSize="0" textAlign="left" href={linkUrl} target="_blank" mt="0.25rem">
+        {linkText}
+    </WaveLink>
+);
+
+// TODO: Document this compound component properly when Storybook migration is complete
+const InfoBannerCard = ({ children, variant = 'info', emphasized, ...props }: CardProps): JSX.Element => {
+    const BannerIcon = ICON_VARIANTS[variant];
+
+    return (
+        <RoundedBox variant={variant} emphasized={emphasized} role={ROLE_VARIANTS[variant]} {...props}>
+            <IconBox mr={1} variant={variant} emphasized={emphasized}>
+                <BannerIcon size={20} color="inherit" />
+            </IconBox>
+            <Box display="flex" flexDirection="column">
+                {children}
+            </Box>
+        </RoundedBox>
+    );
+};
+
+InfoBannerCard.Title = Title;
+InfoBannerCard.Description = Description;
+InfoBannerCard.Link = Link;
+InfoBannerCard.LinkList = LinkList;
+
+export { InfoBannerCard };

--- a/src/components/InfoBanner/docs/InfoBanner.mdx
+++ b/src/components/InfoBanner/docs/InfoBanner.mdx
@@ -23,7 +23,6 @@ The InfoBanner is used to communicate a vibrant message, state change or importa
 
 
 ## Examples
-
 <InfoBanner mt={2} title='Please do not share details about this information.' description='In case of uncertainty please contact Fraud department.' />
 <br />
 <InfoBanner title='Possible Fraud' description='This passenger has more than 20 linked accounts.' variant='warning' />
@@ -38,21 +37,17 @@ Available compound components:
 - **InfoBannerCard** (Wrapper)
 - **InfoBannerCard.Title**
 - **InfoBannerCard.Description**
-- **InfoBannerCard.LinkList**
 - **InfoBannerCard.Link**
 
 The wrapper component (**InfoBannerCard**) accepts same props as **InfoBanner** component, if variant is applied, it's styling will get automatically applied to children compound components.
-
 
 <Playground>
     <InfoBannerCard variant='warning'>
         <InfoBannerCard.Title>Issue with documents</InfoBannerCard.Title>
         <InfoBannerCard.Description>Your uploaded documents don't match the records. Please check the following sources:</InfoBannerCard.Description>
-        <InfoBannerCard.LinkList>
-            <li><InfoBannerCard.Link linkText='Driver documents' linkUrl='https://wave.free-now.com' /></li>
-            <li><InfoBannerCard.Link linkText='Vehicle documents' linkUrl='https://wave.free-now.com' /></li>
-            <li><InfoBannerCard.Link linkText='Driver Profile' linkUrl='https://wave.free-now.com' /></li>
-        </InfoBannerCard.LinkList>
+            <InfoBannerCard.Link linkText='Driver documents' linkUrl='https://wave.free-now.com' />
+            <InfoBannerCard.Link linkText='Vehicle documents' linkUrl='https://wave.free-now.com' />
+            <InfoBannerCard.Link linkText='Driver Profile' linkUrl='https://wave.free-now.com' />
     </InfoBannerCard>
 </Playground>
 

--- a/src/components/InfoBanner/docs/InfoBanner.mdx
+++ b/src/components/InfoBanner/docs/InfoBanner.mdx
@@ -6,6 +6,7 @@ route: /components/info-banner
 
 import { Playground } from 'docz';
 import { InfoBanner } from '../InfoBanner'
+import { InfoBannerCard } from '../blocks/InfoBannerCard'
 import { InfoBannerPropsTable } from './InfoBannerPropsTable'
 import { Combination } from '../../../docs/Combination'
 import { StyledSystemLinks } from '../../../docs/StyledSystemLinks'
@@ -23,10 +24,37 @@ The InfoBanner is used to communicate a vibrant message, state change or importa
 
 ## Examples
 
-<InfoBanner title='Please do not share details about this information.' description='In case of uncertainty please contact Fraud department.' />
+<InfoBanner mt={2} title='Please do not share details about this information.' description='In case of uncertainty please contact Fraud department.' />
 <br />
 <InfoBanner title='Possible Fraud' description='This passenger has more than 20 linked accounts.' variant='warning' />
 
+<br/>
+
+## Compound components approach
+
+You may also use compound components approach to build up your InfoBanner (e.g. when you need multiple links in a single banner as below)
+
+Available compound components:
+- **InfoBannerCard** (Wrapper)
+- **InfoBannerCard.Title**
+- **InfoBannerCard.Description**
+- **InfoBannerCard.LinkList**
+- **InfoBannerCard.Link**
+
+The wrapper component (**InfoBannerCard**) accepts same props as **InfoBanner** component, if variant is applied, it's styling will get automatically applied to children compound components.
+
+
+<Playground>
+    <InfoBannerCard variant='warning'>
+        <InfoBannerCard.Title>Issue with documents</InfoBannerCard.Title>
+        <InfoBannerCard.Description>Your uploaded documents don't match the records. Please check the following sources:</InfoBannerCard.Description>
+        <InfoBannerCard.LinkList>
+            <li><InfoBannerCard.Link linkText='Driver documents' linkUrl='https://wave.free-now.com' /></li>
+            <li><InfoBannerCard.Link linkText='Vehicle documents' linkUrl='https://wave.free-now.com' /></li>
+            <li><InfoBannerCard.Link linkText='Driver Profile' linkUrl='https://wave.free-now.com' /></li>
+        </InfoBannerCard.LinkList>
+    </InfoBannerCard>
+</Playground>
 
 ## Playground
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -55,3 +55,4 @@ export { SelectListProps } from './SelectList/types';
 export { Row, RowProps, Column, ColumnProps } from './Grid/Grid';
 export { Popover, PopoverProps } from './Popover/Popover';
 export { InfoBanner, InfoBannerProps, InfoBannerVariants } from './InfoBanner/InfoBanner';
+export { InfoBannerCard } from './InfoBanner/blocks/InfoBannerCard';


### PR DESCRIPTION
**What:**
Implementing the compound components approach for building out the InfoBanner component (with multiple links as required for one of our products atm)
​
**Why:**
Explanation & Discussion: https://github.com/freenowtech/wave/issues/335

**How:**
- Create building blocks for InfoBanner: InfoBannerCard wrapper + blocks: Title, Description, LinkList (with defined spacing), Link
- Keeping the original component as is

**Media:**
<img width="802" alt="Screenshot 2023-05-23 at 16 19 11" src="https://github.com/freenowtech/wave/assets/14894844/fb905246-1ad1-4ec9-a06c-20238ccc3c41">

**Extra**
Added some temporary documentation, will document properly on Storybook after migration is complete, as this will go directly to **main** before migration.

**Checklist:**
-   [ ] Ready to be merged
