### PR TITLE
fix: add support for children props inside Label component

### DIFF
--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { compose, margin, MarginProps, ResponsiveValue, variant } from 'styled-system';
+import { ComponentPropsWithoutRef } from 'react';
 import { Text } from '../Text/Text';
 import { Colors } from '../../essentials';
 import { theme } from '../../essentials/theme';
 import { get } from '../../utils/themeGet';
 
-interface LabelProps extends MarginProps {
+interface LabelProps extends ComponentPropsWithoutRef<'span'>, MarginProps {
     /**
      * Set the appropriate colors for the component with 'default' as a default
      */


### PR DESCRIPTION
**What:**

Add support for children props inside Label component.

​
**Why:**

When using the Label component, the console shows following error:
```Type '{ children: string; }' has no properties in common with type 'IntrinsicAttributes & LabelProps'.```

​
**How:**

Extend the LabelProps with ```ComponentPropsWithoutRef<'span'>```
