### PR TITLE
fix: support children prop type in row component

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -16,7 +16,7 @@ const BorderBoxWrapper = styled(Box)`
 
 type RowProps = BoxProps;
 
-const Row: FC<RowProps> = (props: RowProps) => (
+const Row: FC<PropsWithChildren<RowProps>> = props => (
     <Box display="flex" flexWrap="wrap" marginRight={`-${GAP}`} {...props} />
 );
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

Add missing `children` prop type definition to `Row` component.

Fixes #345.

**Why:**

`children` prop type was not supported for `Row` component.
​
**How:**

Extending component props with `PropsWithChildren`.
​
**Media:**

N/A

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
