### PR TITLE
Render Tooltip via React Portal

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import { variant } from 'styled-system';
 
 import type { PropsWithChildren } from 'react';
 
-import { MediaQueries, SemanticColors } from '../../essentials';
+import { Elevation, MediaQueries, SemanticColors } from '../../essentials';
 import { get } from '../../utils/themeGet';
 import { Text } from '../Text/Text';
 import { mapPlacementWithDeprecationWarning, TooltipPlacement } from './TooltipPlacement';
@@ -90,6 +90,7 @@ interface TooltipBodyProps {
 
 const TooltipBody = styled.div<TooltipBodyProps>`
     position: relative;
+    z-index: ${Elevation.TOOLTIP};
     background-color: ${p =>
         p.inverted ? SemanticColors.background.secondary : SemanticColors.background.primaryEmphasized};
     padding: 0.25rem 0.5rem;
@@ -139,10 +140,6 @@ interface TooltipProps {
      * Force the tooltip to always be visible, regardless of user interaction
      */
     alwaysVisible?: boolean;
-    /**
-     * Render the tooltip into a certain DOM node. One use case is when the tooltip should "hover" over the entire page and shouldn't trigger any scrollbars to appear
-     */
-    container?: Element | DocumentFragment;
 }
 
 const Tooltip: React.FC<PropsWithChildren<TooltipProps>> = ({
@@ -150,8 +147,7 @@ const Tooltip: React.FC<PropsWithChildren<TooltipProps>> = ({
     children,
     placement = 'top',
     alwaysVisible = false,
-    inverted = false,
-    container
+    inverted = false
 }) => {
     const [isVisible, setIsVisible] = React.useState(alwaysVisible);
     /**
@@ -196,25 +192,6 @@ const Tooltip: React.FC<PropsWithChildren<TooltipProps>> = ({
         }
     };
 
-    const renderTooltipBody = () => {
-        const tooltipBody = (
-            <TooltipBody
-                ref={setContentReference}
-                inverted={inverted}
-                style={{ ...styles.popper }}
-                variant={attributes.popper?.['data-popper-placement']}
-                {...attributes.popper}
-            >
-                {dynamicContent}
-            </TooltipBody>
-        );
-
-        if (container) {
-            return createPortal(tooltipBody, container);
-        }
-        return tooltipBody;
-    };
-
     return (
         <>
             {React.cloneElement(children as React.ReactElement, {
@@ -222,7 +199,20 @@ const Tooltip: React.FC<PropsWithChildren<TooltipProps>> = ({
                 onMouseOut: () => handleVisibilityChange(false),
                 ref: setTriggerReference
             })}
-            {content && isVisible && renderTooltipBody()}
+            {content &&
+                isVisible &&
+                createPortal(
+                    <TooltipBody
+                        ref={setContentReference}
+                        inverted={inverted}
+                        style={{ ...styles.popper }}
+                        variant={attributes.popper?.['data-popper-placement']}
+                        {...attributes.popper}
+                    >
+                        {dynamicContent}
+                    </TooltipBody>,
+                    document.body
+                )}
         </>
     );
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->
In this PR we're adding a new prop `container` to the `Tooltip` component where the tooltip should be rendered into.
​
**Why:**

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
This PR closes #349.

Tooltips that are rendered in Modal dialogs can cause scrollbars to appear. It was not like that in previous version of wave (1.15.1).

**How:**

<!-- Often a list of things to describe the process to accomplish this PR -->
* Introduce new (optional) prop `container` to Tooltip component where the tooltip body should be rendered into
* Render the tooltip body into `container` via react portal
* See [internal discussion](https://mytaxi.slack.com/archives/CLM50RECU/p1690799683872489) 
* Implementation according to [popper library documentation](https://popper.js.org/react-popper/v2/react-portals/) 
​
**Media:**

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->
Before:
![image](https://github.com/freenowtech/wave/assets/2736136/acc15117-45ed-4c93-b29e-a02a4d967a43)

After:
<img width="591" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/7b90620c-3b72-4126-b7ab-39a87de8d365">


**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [ ] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
