### PR TITLE
Add variants of tag component in Tag and SelectList

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,5 +3,12 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 <link rel="manifest" href="/site.webmanifest" />
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+<link href="https://fonts.googleapis.com/css?family=Open+Sans:200,300,400,400i,600,600i,700,800" rel="stylesheet" />
 <meta name="msapplication-TileColor" content="#da532c" />
 <meta name="theme-color" content="#ffffff" />
+
+<style>
+    body {
+        font-family: 'Open Sans', sans-serif;
+    }
+</style>

--- a/src/components/SelectList/SelectList.spec.tsx
+++ b/src/components/SelectList/SelectList.spec.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { SelectList } from './SelectList';
+import { SemanticColors } from '../../essentials';
+
+describe('SelectList', () => {
+    it('renders options in multi select', () => {
+        const options = [
+            {
+                label: 'Sales',
+                value: 'sales'
+            },
+            {
+                label: 'Marketing',
+                value: 'marketing',
+                error: true
+            }
+        ];
+
+        render(<SelectList options={options} value={options} isMulti />);
+
+        const normalTag = screen.getByText('Sales').parentElement;
+        expect(normalTag).toHaveStyle(`
+            background-color: ${SemanticColors.background.info};
+            border-color: ${SemanticColors.border.infoEmphasized};
+        `);
+
+        const errorTag = screen.getByText('Marketing').parentElement;
+        expect(errorTag).toHaveStyle(`
+            background-color: transparent;
+            border-color: ${SemanticColors.border.dangerEmphasized};
+        `);
+    });
+
+    it('disables options in multi select when control is disabled', () => {
+        const options = [
+            {
+                label: 'Sales',
+                value: 'sales'
+            },
+            {
+                label: 'Marketing',
+                value: 'marketing',
+                error: true
+            }
+        ];
+
+        render(<SelectList options={options} value={options} isMulti isDisabled />);
+
+        const normalTag = screen.getByText('Sales').parentElement;
+        expect(normalTag).toHaveStyle(`
+            background-color: transparent;
+            border-color: ${SemanticColors.border.primary};
+        `);
+
+        const errorTag = screen.getByText('Marketing').parentElement;
+        expect(errorTag).toHaveStyle(`
+            background-color: transparent;
+            border-color: ${SemanticColors.border.primary};
+        `);
+    });
+});

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -21,6 +21,19 @@ import { SelectListProps } from './types';
 
 type WithSelectProps<T> = T & { selectProps: SelectListProps };
 
+const getOptionError = (option: unknown): boolean =>
+    typeof option === 'object' && 'error' in option && Boolean(option.error);
+
+const getOptionVariant = (selectProps: Props, option: unknown): 'default' | 'disabled' | 'error' => {
+    if (selectProps.isDisabled) {
+        return 'disabled';
+    }
+
+    return !getOptionError(option) ? 'default' : 'error';
+};
+
+const getColor = (key: string, props: Props) => String(get(key)(props));
+
 const customStyles: StylesConfig = {
     container: (provided, { selectProps }: WithSelectProps<Props>) => {
         const bSize = {
@@ -169,35 +182,79 @@ const customStyles: StylesConfig = {
             cursor: state.isDisabled ? 'not-allowed' : 'default'
         };
     },
-    multiValue: (provided, { selectProps }: { selectProps: Props }) => {
+    multiValue: (provided, { selectProps, data }) => {
+        const optionVariant = getOptionVariant(selectProps, data);
+
         const styles = {
             ...provided,
-            color: Colors.ACTION_BLUE_900,
-            border: `0.0625rem solid ${Colors.ACTION_BLUE_900}`,
+            border: `0.0625rem solid`,
             borderRadius: '1rem',
-            backgroundColor: Colors.ACTION_BLUE_50,
             marginRight: '0.375rem',
             marginTop: '0.125rem',
             marginLeft: 0,
             marginBottom: '0.125rem',
             maxWidth: 'calc(100% - 0.5rem)',
-            transition: 'color 125ms ease, background-color 125ms ease',
-            '&:hover': {
-                backgroundColor: Colors.ACTION_BLUE_900,
-                color: Colors.WHITE
-            }
+            transition: 'color 125ms ease, background-color 125ms ease'
         };
 
-        if (selectProps.isDisabled) {
-            return {
-                ...styles,
-                color: Colors.AUTHENTIC_BLUE_200,
-                backgroundColor: 'transparent',
-                borderColor: Colors.AUTHENTIC_BLUE_200
-            };
-        }
+        switch (optionVariant) {
+            case 'disabled':
+                return {
+                    ...styles,
 
-        return styles;
+                    color: getColor('semanticColors.text.disabled', selectProps),
+                    backgroundColor: 'transparent',
+                    borderColor: getColor('semanticColors.border.primary', selectProps),
+
+                    '> [role="button"]': {
+                        color: getColor('semanticColors.icon.disabled', selectProps)
+                    }
+                };
+            case 'error':
+                return {
+                    ...styles,
+                    color: getColor('semanticColors.text.dangerInverted', selectProps),
+                    backgroundColor: 'transparent',
+                    borderColor: getColor('semanticColors.border.dangerEmphasized', selectProps),
+
+                    '> [role="button"]': {
+                        color: getColor('semanticColors.icon.danger', selectProps)
+                    },
+
+                    '&:hover': {
+                        color: getColor('semanticColors.text.primaryInverted', selectProps),
+                        backgroundColor: getColor('semanticColors.background.dangerEmphasized', selectProps),
+                        borderColor: getColor('semanticColors.border.dangerEmphasized', selectProps),
+
+                        '> [role="button"]': {
+                            color: getColor('semanticColors.icon.primaryInverted', selectProps)
+                        }
+                    }
+                };
+            case 'default':
+            default:
+                return {
+                    ...styles,
+
+                    color: getColor('semanticColors.text.link', selectProps),
+                    backgroundColor: getColor('semanticColors.background.info', selectProps),
+                    borderColor: getColor('semanticColors.border.infoEmphasized', selectProps),
+
+                    '> [role="button"]': {
+                        color: getColor('semanticColors.icon.action', selectProps)
+                    },
+
+                    '&:hover': {
+                        color: getColor('semanticColors.text.primaryInverted', selectProps),
+                        backgroundColor: getColor('semanticColors.background.infoEmphasized', selectProps),
+                        borderColor: getColor('semanticColors.border.infoEmphasized', selectProps),
+
+                        '> [role="button"]': {
+                            color: getColor('semanticColors.icon.primaryInverted', selectProps)
+                        }
+                    }
+                };
+        }
     },
     multiValueLabel: (provided, { selectProps }) => ({
         ...provided,
@@ -214,6 +271,7 @@ const customStyles: StylesConfig = {
         paddingLeft: '0',
         paddingRight: '0.25rem',
         paddingTop: '0',
+        transition: 'color 125ms ease',
         '&:hover': {
             color: 'inherit',
             background: 'transparent'

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -29,7 +29,11 @@ const getOptionVariant = (selectProps: Props, option: unknown): 'default' | 'dis
         return 'disabled';
     }
 
-    return !getOptionError(option) ? 'default' : 'error';
+    if (getOptionError(option)) {
+        return 'error';
+    }
+
+    return 'default';
 };
 
 const getColor = (key: string, props: Props) => String(get(key)(props));
@@ -187,7 +191,7 @@ const customStyles: StylesConfig = {
 
         const styles = {
             ...provided,
-            border: `0.0625rem solid`,
+            border: '0.0625rem solid',
             borderRadius: '1rem',
             marginRight: '0.375rem',
             marginTop: '0.125rem',

--- a/src/components/SelectList/docs/SelectList.stories.tsx
+++ b/src/components/SelectList/docs/SelectList.stories.tsx
@@ -75,6 +75,39 @@ export const WithError: Story = {
     }
 };
 
+const errorOptions = [
+    {
+        label: 'Sales',
+        value: 'sales'
+    },
+    {
+        label: 'Marketing',
+        value: 'marketing',
+        error: true
+    }
+];
+
+export const MultiSelectError: Story = {
+    args: {
+        label: 'Multi select with error',
+        error: true,
+        isMulti: true,
+        options: errorOptions,
+        value: errorOptions
+    }
+};
+
+export const MultiSelectDisabled: Story = {
+    args: {
+        label: 'Disabled multi select',
+        error: true,
+        isMulti: true,
+        isDisabled: true,
+        options: errorOptions,
+        value: errorOptions
+    }
+};
+
 export const Inverted: Story = {
     args: {
         inverted: true

--- a/src/components/Tag/Tag.spec.tsx
+++ b/src/components/Tag/Tag.spec.tsx
@@ -1,6 +1,7 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import * as React from 'react';
 import { Tag } from './Tag';
+import { SemanticColors } from '../../essentials';
 
 describe('Tag', () => {
     it('renders with default props', () => {
@@ -25,5 +26,34 @@ describe('Tag', () => {
         );
 
         expect(queryByTestId('dismiss-icon')).toBeNull();
+    });
+
+    it('renders disabled variant', () => {
+        const { container } = render(<Tag variant="disabled">Lorem</Tag>);
+
+        expect(container.firstChild).toHaveStyle(`
+            border-color: ${SemanticColors.border.primary};
+        `);
+        expect(screen.getByText('Lorem')).toHaveStyle(`
+            color: ${SemanticColors.text.disabled};
+        `);
+        expect(screen.getByTestId('dismiss-icon')).toHaveStyle(`
+            color: ${SemanticColors.icon.disabled};
+        `);
+    });
+
+    it('renders error variant', () => {
+        const { container } = render(<Tag variant="error">Lorem</Tag>);
+
+        expect(container.firstChild).toHaveStyle(`
+            background-color: ${SemanticColors.background.danger};
+            border-color: ${SemanticColors.border.dangerEmphasized};
+        `);
+        expect(screen.getByText('Lorem')).toHaveStyle(`
+            color: ${SemanticColors.text.dangerInverted};
+        `);
+        expect(screen.getByTestId('dismiss-icon')).toHaveStyle(`
+            color: ${SemanticColors.icon.danger};
+        `);
     });
 });

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 import React, { FC, MouseEvent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
-import { margin, MarginProps } from 'styled-system';
+import { margin, MarginProps, variant } from 'styled-system';
 
 import { Colors } from '../../essentials';
 import { theme } from '../../essentials/theme';
@@ -17,10 +17,14 @@ interface TagProps extends MarginProps {
      * The prop to determine whether the dismiss functionality is enabled
      */
     dismissible?: boolean;
+    /**
+     * Set the appropriate semantic tag color.
+     * @default default
+     */
+    variant?: 'default' | 'disabled' | 'error';
 }
 
 const TagText = styled(Text).attrs({ theme })<Pick<TagProps, 'dismissible'>>`
-    color: ${Colors.ACTION_BLUE_900};
     margin-left: 0.75rem;
     margin-right: ${props => (props.dismissible ? '0.25rem' : '0.75rem')};
     font-size: ${get('fontSizes.1')};
@@ -38,10 +42,75 @@ const DismissIcon = styled(CloseIcon).attrs({ size: 18 })`
     }
 `;
 
+const tagVariant = variant({
+    variants: {
+        default: {
+            backgroundColor: get('semanticColors.background.info'),
+            borderColor: get('semanticColors.border.infoEmphasized'),
+
+            [`> ${TagText}`]: {
+                color: get('semanticColors.text.link')
+            },
+
+            [`> ${DismissIcon}`]: {
+                color: get('semanticColors.icon.action')
+            },
+
+            '&:hover': {
+                backgroundColor: get('semanticColors.background.infoEmphasized'),
+                borderColor: get('semanticColors.border.infoEmphasized'),
+
+                [`> ${TagText}`]: {
+                    color: get('semanticColors.text.primaryInverted')
+                },
+
+                [`> ${DismissIcon}`]: {
+                    color: get('semanticColors.icon.primaryInverted')
+                }
+            }
+        },
+        disabled: {
+            borderColor: get('semanticColors.border.primary'),
+
+            [`> ${TagText}`]: {
+                color: get('semanticColors.text.disabled')
+            },
+
+            [`> ${DismissIcon}`]: {
+                color: get('semanticColors.icon.disabled')
+            }
+        },
+        error: {
+            backgroundColor: get('semanticColors.background.danger'),
+            borderColor: get('semanticColors.border.dangerEmphasized'),
+
+            [`> ${TagText}`]: {
+                color: get('semanticColors.text.dangerInverted')
+            },
+
+            [`> ${DismissIcon}`]: {
+                color: get('semanticColors.icon.danger')
+            },
+
+            '&:hover': {
+                backgroundColor: get('semanticColors.background.dangerEmphasized'),
+                borderColor: get('semanticColors.border.dangerEmphasized'),
+
+                [`> ${TagText}`]: {
+                    color: get('semanticColors.text.primaryInverted')
+                },
+
+                [`> ${DismissIcon}`]: {
+                    color: get('semanticColors.icon.primaryInverted')
+                }
+            }
+        }
+    }
+});
+
 const TagWrapper = styled.div.attrs({ theme })<TagProps>`
     box-sizing: border-box;
-    background-color: ${Colors.ACTION_BLUE_50};
-    border: solid 0.0625rem ${Colors.ACTION_BLUE_900};
+    border: solid 0.0625rem;
     display: inline-flex;
     align-items: center;
     border-radius: 2rem;
@@ -52,25 +121,19 @@ const TagWrapper = styled.div.attrs({ theme })<TagProps>`
     transition: background-color 125ms ease;
 
     ${margin}
-
-    &:hover {
-        background-color: ${Colors.ACTION_BLUE_900};
-
-        > ${TagText} {
-            color: ${Colors.WHITE};
-        }
-
-        > ${DismissIcon} {
-            color: ${Colors.WHITE};
-        }
-    }
+    ${tagVariant}
 `;
 
-const Tag: FC<PropsWithChildren<TagProps>> = ({ children, onDismiss, dismissible = true, ...rest }) => (
+const Tag: FC<PropsWithChildren<TagProps>> = ({ children, onDismiss, dismissible, ...rest }) => (
     <TagWrapper {...rest}>
         <TagText dismissible={dismissible}>{children}</TagText>
         {dismissible && <DismissIcon data-testid="dismiss-icon" color={Colors.ACTION_BLUE_900} onClick={onDismiss} />}
     </TagWrapper>
 );
+
+Tag.defaultProps = {
+    dismissible: true,
+    variant: 'default'
+};
 
 export { Tag, TagProps };

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -124,16 +124,17 @@ const TagWrapper = styled.div.attrs({ theme })<TagProps>`
     ${tagVariant}
 `;
 
-const Tag: FC<PropsWithChildren<TagProps>> = ({ children, onDismiss, dismissible, ...rest }) => (
-    <TagWrapper {...rest}>
+const Tag: FC<PropsWithChildren<TagProps>> = ({
+    children,
+    onDismiss,
+    dismissible = true,
+    variant: variantValue = 'default',
+    ...rest
+}) => (
+    <TagWrapper variant={variantValue} {...rest}>
         <TagText dismissible={dismissible}>{children}</TagText>
         {dismissible && <DismissIcon data-testid="dismiss-icon" color={Colors.ACTION_BLUE_900} onClick={onDismiss} />}
     </TagWrapper>
 );
-
-Tag.defaultProps = {
-    dismissible: true,
-    variant: 'default'
-};
 
 export { Tag, TagProps };

--- a/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -10,7 +10,6 @@ exports[`Tag renders with default props 1`] = `
 }
 
 .c3 {
-  color: #096BDB;
   margin-left: 0.75rem;
   margin-right: 0.25rem;
   font-size: 0.875rem;
@@ -32,8 +31,7 @@ exports[`Tag renders with default props 1`] = `
 
 .c0 {
   box-sizing: border-box;
-  background-color: #F1F7FD;
-  border: solid 0.0625rem #096BDB;
+  border: solid 0.0625rem;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -49,10 +47,21 @@ exports[`Tag renders with default props 1`] = `
   padding: 0.375rem 0;
   -webkit-transition: background-color 125ms ease;
   transition: background-color 125ms ease;
+  background-color: #F1F7FD;
+  border-color: #096BDB;
+}
+
+.c0 > .c1 {
+  color: #096BDB;
+}
+
+.c0 > .c4 {
+  color: #096BDB;
 }
 
 .c0:hover {
   background-color: #096BDB;
+  border-color: #096BDB;
 }
 
 .c0:hover > .c1 {


### PR DESCRIPTION
**What:**

 Error Variant for Tag and SelectList Options (#354).
​
**Why:**

We want to highlight certain items to make it clear to the users that those are invalid and they should remove them. Otherwise the configuration will be considered broken.
​
**How:**

- Fix missing Open Sans font in storybook
- Add storybook stories for SelectList with multi select
- Support new `variant = "default" | "disabled" | "error"` property in the Tag component
- Support having "error" property on options of SelectList element to render the entry tag in "error" variant
- Use semantic colors in accordance with design specification for tags in Tag and SelectList
​

**Media:**

Tag:

![default](https://github.com/freenowtech/wave/assets/420178/900eb5bc-755b-4d2b-b9d1-5c24b4e8878c)

![disabled](https://github.com/freenowtech/wave/assets/420178/71be0fcc-4d05-43c2-b135-854b70d93ed6)

![error](https://github.com/freenowtech/wave/assets/420178/733a4493-b9ff-4d00-ade2-0285ecea93af)

SelectList:

![image](https://github.com/freenowtech/wave/assets/420178/c6631988-099f-42c0-ab28-a8b5e59bad0a)

![image](https://github.com/freenowtech/wave/assets/420178/765f89cc-4f1a-4268-ac95-995c936c16d1)


**Checklist:**

-   [ ] Ready to be merged
