### PR TITLE
refactor: replace deprecated weak prop for secondary in text usages

### DIFF
--- a/src/components/FilePicker/FilePicker.tsx
+++ b/src/components/FilePicker/FilePicker.tsx
@@ -100,17 +100,17 @@ const Outliner = styled(Box)<OutlinerProps>`
     ${({ hasValidFile }) =>
         hasValidFile &&
         css`
-                ${MediaQueries.medium} {
-                    &:hover {
-                        background-color: ${Colors.ACTION_BLUE_50};
-                        border-color: ${Colors.ACTION_BLUE_50};
+            ${MediaQueries.medium} {
+                &:hover {
+                    background-color: ${Colors.ACTION_BLUE_50};
+                    border-color: ${Colors.ACTION_BLUE_50};
 
-                        svg:not([color='${Colors.POSITIVE_GREEN_900}']) path {
-                            fill: ${Colors.ACTION_BLUE_900};
-                        }
+                    svg:not([color='${Colors.POSITIVE_GREEN_900}']) path {
+                        fill: ${Colors.ACTION_BLUE_900};
                     }
                 }
-            `}
+            }
+        `}
 `;
 
 const Input = styled.input`
@@ -190,7 +190,7 @@ const FilePicker: FC<FilePickerProps> = ({
                     <Text as="label" htmlFor={name} fontSize={1}>
                         {label}
                     </Text>
-                    <Text weak fontSize={1}>
+                    <Text secondary fontSize={1}>
                         {file && shrinkFileName(file)}
                     </Text>
                 </Box>
@@ -204,9 +204,13 @@ const FilePicker: FC<FilePickerProps> = ({
                     )}
                 </Box>
                 <Box display={{ _: 'flex', medium: 'none' }} alignItems="top">
-                    {!alwaysShowActionButton && validFileSelected ? <CheckCircleOutlineIcon color={ICON_FILE_FEEDBACK_COLOR} /> : <ShareIcon />}
+                    {!alwaysShowActionButton && validFileSelected ? (
+                        <CheckCircleOutlineIcon color={ICON_FILE_FEEDBACK_COLOR} />
+                    ) : (
+                        <ShareIcon />
+                    )}
                 </Box>
-            </Outliner> 
+            </Outliner>
         </Box>
     );
 };

--- a/src/components/Modal/docs/ModalCreator.tsx
+++ b/src/components/Modal/docs/ModalCreator.tsx
@@ -5,7 +5,7 @@ import { Modal } from '../Modal';
 export const modalContent = (dismiss: () => void): React.ReactElement => (
     <>
         <Headline as="h2">Add Note</Headline>
-        <Text as="p" weak my={3}>
+        <Text as="p" secondary my={3}>
             Please keep in mind that comments are also read by other agents. Make sure to write comprehensible text.
         </Text>
         <Button onClick={dismiss}>Add Note</Button>

--- a/src/components/Pagination/docs/PaginationProvider.tsx
+++ b/src/components/Pagination/docs/PaginationProvider.tsx
@@ -87,9 +87,9 @@ const NormalPagination: React.FC = () => (
                 pageSize={pageSize}
                 totalItems={totalItems}
                 label={
-                    <Text weak>
+                    <Text secondary>
                         Page{' '}
-                        <Text as="b" fontWeight="semibold" weak>
+                        <Text as="b" fontWeight="semibold" secondary>
                             {currentPage} of {Math.ceil(totalItems / pageSize)}
                         </Text>
                     </Text>
@@ -122,9 +122,9 @@ const PaginationWithPageSize: React.FC = () => (
                 pageSizes={pageSizes}
                 totalItems={totalItems}
                 label={
-                    <Text weak>
+                    <Text secondary>
                         Page{' '}
-                        <Text as="b" fontWeight="semibold" weak>
+                        <Text as="b" fontWeight="semibold" secondary>
                             {currentPage} of {Math.ceil(totalItems / pageSize)}
                         </Text>
                     </Text>

--- a/src/components/Table/docs/ComplexDataTable.tsx
+++ b/src/components/Table/docs/ComplexDataTable.tsx
@@ -32,14 +32,14 @@ export const ComplexDataTable: FC = () => (
                 <TableCell>
                     Große Elbstraße 273
                     <br />
-                    <Text fontSize={1} weak>
+                    <Text fontSize={1} secondary>
                         22767 Hamburg
                     </Text>
                 </TableCell>
                 <TableCell>
                     Holsteiner Chaussee 191
                     <br />
-                    <Text fontSize={1} weak>
+                    <Text fontSize={1} secondary>
                         22457 Hamburg
                     </Text>
                 </TableCell>
@@ -73,7 +73,7 @@ export const ComplexDataTable: FC = () => (
                 <TableCell>
                     Große Elbstraße 273
                     <br />
-                    <Text fontSize={1} weak>
+                    <Text fontSize={1} secondary>
                         22767 Hamburg
                     </Text>
                 </TableCell>
@@ -95,14 +95,14 @@ export const ComplexDataTable: FC = () => (
                 <TableCell>
                     Große Elbstraße 273
                     <br />
-                    <Text fontSize={1} weak>
+                    <Text fontSize={1} secondary>
                         22767 Hamburg
                     </Text>
                 </TableCell>
                 <TableCell>
                     Große Elbstraße 273
                     <br />
-                    <Text fontSize={1} weak>
+                    <Text fontSize={1} secondary>
                         22767 Hamburg
                     </Text>
                 </TableCell>

--- a/src/components/Table/docs/DefaultTable.tsx
+++ b/src/components/Table/docs/DefaultTable.tsx
@@ -23,7 +23,7 @@ export const DefaultTable: FC = (args: TableProps) => (
                 <TableCell>
                     5 July 2019 - 11:14
                     <br />
-                    <Text fontSize={0} weak>
+                    <Text fontSize={0} secondary>
                         No activity yet
                     </Text>
                 </TableCell>
@@ -53,7 +53,7 @@ export const DefaultTable: FC = (args: TableProps) => (
                 <TableCell>
                     27 February 2020 - 16:02
                     <br />
-                    <Text fontSize={0} weak>
+                    <Text fontSize={0} secondary>
                         17 Tours
                     </Text>
                 </TableCell>
@@ -83,7 +83,7 @@ export const DefaultTable: FC = (args: TableProps) => (
                 <TableCell>
                     30 March 2020 - 18:19
                     <br />
-                    <Text fontSize={0} weak>
+                    <Text fontSize={0} secondary>
                         17 Tours
                     </Text>
                 </TableCell>

--- a/src/components/Table/docs/SkeletonTable.tsx
+++ b/src/components/Table/docs/SkeletonTable.tsx
@@ -66,7 +66,7 @@ export const SkeletonTable: FC = () => {
                                 <TableCell>
                                     {entry.date}
                                     <br />
-                                    <Text fontSize={0} weak>
+                                    <Text fontSize={0} secondary>
                                         {entry.activity}
                                     </Text>
                                 </TableCell>

--- a/src/essentials/Spaces/docs/SpacesContainer.tsx
+++ b/src/essentials/Spaces/docs/SpacesContainer.tsx
@@ -38,7 +38,7 @@ const SpacesContainer: React.FC = () => (
                     <Text mt={1} fontSize={1} style={{ color: 'inherit' }}>
                         {space}
                     </Text>
-                    <Text mb={2} fontSize={1} weak>
+                    <Text mb={2} fontSize={1} secondary>
                         {Number(space.replace('rem', '')) * 16}px
                     </Text>
                     <SpaceSquare space={Spaces[index]} />


### PR DESCRIPTION
**What:**

Replace the deprecated `weak` prop in favour of `secondary` in internal usages of the `Text` component

​
**Why:**

The `weak` prop is deprecated so we shouldn't use it, on top of that using it throws a warning which bubbles up to external projects that use Wave components with usages of `weak`

​
**How:**

Replace all usages of `weak` prop of `Text` components

**Checklist:**

-   [x] Ready to be merged

Closes #304
