### PR TITLE
feat: adding aria-invalid when an input has an error for accessibility

### DIFF
--- a/src/components/Input/InnerInput.tsx
+++ b/src/components/Input/InnerInput.tsx
@@ -44,6 +44,7 @@ const InnerInput = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>(
                         size={size}
                         hasValue={hasValue || hasUncontrolledValue}
                         onChange={handleChange}
+                        aria-invalid={rest.error}
                     />
                     {label && (
                         <BoxedInputLabel htmlFor={id} size={size}>
@@ -64,6 +65,7 @@ const InnerInput = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>(
                         size={size}
                         hasValue={hasValue || hasUncontrolledValue}
                         onChange={handleChange}
+                        aria-invalid={rest.error}
                     />
                     {label && (
                         <BottomLinedInputLabel htmlFor={id} size={size}>

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -193,6 +193,7 @@ exports[`Input variant "bottom-lined" renders the error state 1`] = `
   class="c0"
 >
   <input
+    aria-invalid="true"
     class="c1 c2"
     id="random"
     type="text"
@@ -347,6 +348,7 @@ exports[`Input variant "bottom-lined" renders the error state with label and pla
   class="c0"
 >
   <input
+    aria-invalid="true"
     class="c1 c2"
     id="random"
     placeholder="FREE NOW"
@@ -1054,6 +1056,7 @@ exports[`Input variant "boxed" renders the error state 1`] = `
   class="c0"
 >
   <input
+    aria-invalid="true"
     class="c1 c2"
     id="random"
     type="text"
@@ -1208,6 +1211,7 @@ exports[`Input variant "boxed" renders the error state with label and placeholde
   class="c0"
 >
   <input
+    aria-invalid="true"
     class="c1 c2"
     id="random"
     placeholder="FREE NOW"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What:**

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->

In this PR we are adding `aria-invalid` to the `Input` component if there is an error
​
**Why:**

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->

​This is for better accessibility, currently we can only assert if an input box contains an error through CSS computations, which is not the best practice
**How:**

<!-- Often a list of things to describe the process to accomplish this PR -->
Add `aria-invalid` if `error` exists
​
**Media:**

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

**Checklist:**

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Release notes added" -->

-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
