### PR TITLE
feat(breadcrumbs): use css variables for colors

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -4,10 +4,10 @@ import styled from 'styled-components';
 import { ChevronRightIcon } from '../../icons';
 import { Text } from '../Text/Text';
 
-import { Colors } from '../../essentials';
 import { theme } from '../../essentials/theme';
 import { get } from '../../utils/themeGet';
 import { Box } from '../Box/Box';
+import { getSemanticValue } from '../../utils/cssVariables';
 
 interface InvertedStyle {
     /**
@@ -53,7 +53,7 @@ const Breadcrumbs = ({ children, inverted }: BreadcrumbsProps): JSX.Element => {
                     </nav>
                     {index < arrayChildren.length - 1 ? (
                         <Box height={16} mt="0.125rem">
-                            <ChevronRightIcon size={16} color={Colors.AUTHENTIC_BLUE_350} />
+                            <ChevronRightIcon size={16} color={getSemanticValue('foreground-neutral-default')} />
                         </Box>
                     ) : // eslint-disable-next-line unicorn/no-null
                     null}
@@ -65,7 +65,10 @@ const Breadcrumbs = ({ children, inverted }: BreadcrumbsProps): JSX.Element => {
 
 const Link = styled.a.attrs({ theme })<LinkProps>`
     display: inline-block;
-    color: ${p => (p.inverted ? Colors.WHITE : Colors.ACTION_BLUE_900)};
+    color: ${p =>
+        p.inverted
+            ? getSemanticValue('foreground-on-background-primary')
+            : getSemanticValue('foreground-accent-default')};
     cursor: pointer;
     line-height: 1.4;
     font-family: ${get('fonts.normal')};
@@ -75,7 +78,10 @@ const Link = styled.a.attrs({ theme })<LinkProps>`
 
     &:hover,
     &:active {
-        color: ${p => (p.inverted ? Colors.AUTHENTIC_BLUE_350 : Colors.ACTION_BLUE_1000)};
+        color: ${p =>
+            p.inverted
+                ? getSemanticValue('foreground-neutral-default')
+                : getSemanticValue('foreground-accent-emphasized')};
         text-decoration: underline;
     }
 `;

--- a/src/components/SelectList/SelectList.spec.tsx
+++ b/src/components/SelectList/SelectList.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { SelectList } from './SelectList';
-import { SemanticColors } from '../../essentials';
+import { getSemanticValue } from '../../utils/cssVariables';
 
 describe('SelectList', () => {
     it('renders options in multi select', () => {
@@ -21,14 +21,14 @@ describe('SelectList', () => {
 
         const normalTag = screen.getByText('Sales').parentElement;
         expect(normalTag).toHaveStyle(`
-            background-color: ${SemanticColors.background.info};
-            border-color: ${SemanticColors.border.infoEmphasized};
+            background-color: ${getSemanticValue('background-element-info-default')};
+            border-color: ${getSemanticValue('border-info-default')};
         `);
 
         const errorTag = screen.getByText('Marketing').parentElement;
         expect(errorTag).toHaveStyle(`
             background-color: transparent;
-            border-color: ${SemanticColors.border.dangerEmphasized};
+            border-color: ${getSemanticValue('border-danger-default')};
         `);
     });
 
@@ -50,13 +50,13 @@ describe('SelectList', () => {
         const normalTag = screen.getByText('Sales').parentElement;
         expect(normalTag).toHaveStyle(`
             background-color: transparent;
-            border-color: ${SemanticColors.border.primary};
+            border-color: ${getSemanticValue('border-disabled')};
         `);
 
         const errorTag = screen.getByText('Marketing').parentElement;
         expect(errorTag).toHaveStyle(`
             background-color: transparent;
-            border-color: ${SemanticColors.border.primary};
+            border-color: ${getSemanticValue('border-disabled')};
         `);
     });
 });

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -37,8 +37,6 @@ const getOptionVariant = (selectProps: Props, option: unknown): 'default' | 'dis
     return 'default';
 };
 
-const getColor = (key: string, props: Props) => String(get(key)(props));
-
 const customStyles: StylesConfig = {
     container: (provided, { selectProps }: WithSelectProps<Props>) => {
         const bSize = {
@@ -219,27 +217,27 @@ const customStyles: StylesConfig = {
                     borderColor: getSemanticValue('border-disabled'),
 
                     '> [role="button"]': {
-                        color: getColor('semanticColors.icon.disabled', selectProps)
+                        color: getSemanticValue('foreground-disabled')
                     }
                 };
             case 'error':
                 return {
                     ...styles,
-                    color: getColor('semanticColors.text.dangerInverted', selectProps),
+                    color: getSemanticValue('foreground-danger-default'),
                     backgroundColor: 'transparent',
-                    borderColor: getColor('semanticColors.border.dangerEmphasized', selectProps),
+                    borderColor: getSemanticValue('border-danger-default'),
 
                     '> [role="button"]': {
-                        color: getColor('semanticColors.icon.danger', selectProps)
+                        color: getSemanticValue('foreground-danger-default')
                     },
 
                     '&:hover': {
-                        color: getColor('semanticColors.text.primaryInverted', selectProps),
-                        backgroundColor: getColor('semanticColors.background.dangerEmphasized', selectProps),
-                        borderColor: getColor('semanticColors.border.dangerEmphasized', selectProps),
+                        color: getSemanticValue('foreground-on-background-danger'),
+                        backgroundColor: getSemanticValue('background-surface-danger-emphasized'),
+                        borderColor: getSemanticValue('border-danger-default'),
 
                         '> [role="button"]': {
-                            color: getColor('semanticColors.icon.primaryInverted', selectProps)
+                            color: getSemanticValue('foreground-on-background-danger')
                         }
                     }
                 };
@@ -252,16 +250,16 @@ const customStyles: StylesConfig = {
                     borderColor: getSemanticValue('border-info-default'),
 
                     '> [role="button"]': {
-                        color: getColor('semanticColors.icon.action', selectProps)
+                        color: getSemanticValue('foreground-info-default')
                     },
 
                     '&:hover': {
                         color: getSemanticValue('foreground-on-background-primary'),
                         backgroundColor: getSemanticValue('background-element-info-emphasized'),
-                        borderColor: getColor('semanticColors.border.infoEmphasized', selectProps),
+                        borderColor: getSemanticValue('border-info-default'),
 
                         '> [role="button"]': {
-                            color: getColor('semanticColors.icon.primaryInverted', selectProps)
+                            color: getSemanticValue('foreground-on-background-info')
                         }
                     }
                 };

--- a/src/components/Tag/Tag.spec.tsx
+++ b/src/components/Tag/Tag.spec.tsx
@@ -1,7 +1,7 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import * as React from 'react';
 import { Tag } from './Tag';
-import { SemanticColors } from '../../essentials';
+import { getSemanticValue } from '../../utils/cssVariables';
 
 describe('Tag', () => {
     it('renders and can be dismissed', () => {
@@ -28,13 +28,13 @@ describe('Tag', () => {
         const { container } = render(<Tag variant="disabled">Lorem</Tag>);
 
         expect(container.firstChild).toHaveStyle(`
-            border-color: ${SemanticColors.border.primary};
+            border-color: ${getSemanticValue('border-disabled')};
         `);
         expect(screen.getByText('Lorem')).toHaveStyle(`
-            color: ${SemanticColors.text.disabled};
+            color: ${getSemanticValue('foreground-disabled')};
         `);
         expect(screen.getByTestId('dismiss-icon')).toHaveStyle(`
-            color: ${SemanticColors.icon.disabled};
+            color: ${getSemanticValue('foreground-disabled')};
         `);
     });
 
@@ -42,14 +42,14 @@ describe('Tag', () => {
         const { container } = render(<Tag variant="error">Lorem</Tag>);
 
         expect(container.firstChild).toHaveStyle(`
-            background-color: ${SemanticColors.background.danger};
-            border-color: ${SemanticColors.border.dangerEmphasized};
+            background-color: ${getSemanticValue('background-surface-danger-default')};
+            border-color: ${getSemanticValue('border-danger-default')};
         `);
         expect(screen.getByText('Lorem')).toHaveStyle(`
-            color: ${SemanticColors.text.dangerInverted};
+            color: ${getSemanticValue('foreground-danger-default')};
         `);
         expect(screen.getByTestId('dismiss-icon')).toHaveStyle(`
-            color: ${SemanticColors.icon.danger};
+            color: ${getSemanticValue('foreground-danger-default')};
         `);
     });
 });

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -50,16 +50,16 @@ const tagVariant = variant({
             borderColor: getSemanticValue('border-info-default'),
 
             [`> ${TagText}`]: {
-                color: get('semanticColors.text.link')
+                color: getSemanticValue('foreground-info-default')
             },
 
             [`> ${DismissIcon}`]: {
-                color: get('semanticColors.icon.action')
+                color: getSemanticValue('foreground-info-default')
             },
 
             '&:hover': {
                 backgroundColor: getSemanticValue('background-element-info-emphasized'),
-                borderColor: get('semanticColors.border.infoEmphasized'),
+                borderColor: getSemanticValue('border-info-default'),
 
                 [`> ${TagText}`]: {
                     color: getSemanticValue('foreground-on-background-info')
@@ -71,38 +71,38 @@ const tagVariant = variant({
             }
         },
         disabled: {
-            borderColor: get('semanticColors.border.primary'),
+            borderColor: getSemanticValue('border-disabled'),
 
             [`> ${TagText}`]: {
-                color: get('semanticColors.text.disabled')
+                color: getSemanticValue('foreground-disabled')
             },
 
             [`> ${DismissIcon}`]: {
-                color: get('semanticColors.icon.disabled')
+                color: getSemanticValue('foreground-disabled')
             }
         },
         error: {
-            backgroundColor: get('semanticColors.background.danger'),
-            borderColor: get('semanticColors.border.dangerEmphasized'),
+            backgroundColor: getSemanticValue('background-surface-danger-default'),
+            borderColor: getSemanticValue('border-danger-default'),
 
             [`> ${TagText}`]: {
-                color: get('semanticColors.text.dangerInverted')
+                color: getSemanticValue('foreground-danger-default')
             },
 
             [`> ${DismissIcon}`]: {
-                color: get('semanticColors.icon.danger')
+                color: getSemanticValue('foreground-danger-default')
             },
 
             '&:hover': {
-                backgroundColor: get('semanticColors.background.dangerEmphasized'),
-                borderColor: get('semanticColors.border.dangerEmphasized'),
+                backgroundColor: getSemanticValue('background-surface-danger-emphasized'),
+                borderColor: getSemanticValue('border-danger-default'),
 
                 [`> ${TagText}`]: {
-                    color: get('semanticColors.text.primaryInverted')
+                    color: getSemanticValue('foreground-on-background-danger')
                 },
 
                 [`> ${DismissIcon}`]: {
-                    color: get('semanticColors.icon.primaryInverted')
+                    color: getSemanticValue('foreground-on-background-danger')
                 }
             }
         }


### PR DESCRIPTION
**What:**

Migrate new `Breadcrumbs` component to use css vars for colors.
​
**Why:**

The `Breadcrumbs` component has been implemented in `main`, where our css variables are not yet available, we want to migrate it to use them so that when Wave 2.0 gets released it's using our new css variables.

​
**How:**

I've migrated all color values in `Breadcrumbs` so they are using `getSemanticValue`. Please review the semantic values that I've chosen and let me know how to improve them, I'm not convinced by the inverted colors 🙏🏽 

​
**Media:**

<img width="655" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/7434fe7f-6425-405e-b089-eb6cd3d32f64">


**Checklist:**

-   [x] Ready to be merged
        
Closes #361 