### PR TITLE
ci: disable semantic-release autopublishing in next

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -29,7 +29,7 @@ jobs:
               run: npm run test
 
     release:
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next'
+        if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
**What:**

Stop autopublishing in `next` branch

​
**Why:**

We've had autopublishing enabled in `next` for a long time but many releases were actually skipped (not published) due to failed jobs in the pipeline. Apart from that there was an incident last Friday (29/09) where a v3 prerelease was published by mistake. Since it brings more issues than help we should disable it for now, we can always enable it back in the future.

​
**How:**

- Remove `next` branch in `release` job of `library.yml` workflow file

​
**Media:**


**Checklist:**

-   [x] Ready to be merged
