### PR TITLE
test: use ES modules in codemods tests

### DIFF
--- a/src/codemods/__tests__/block-to-width-100-test.ts
+++ b/src/codemods/__tests__/block-to-width-100-test.ts
@@ -1,4 +1,4 @@
 jest.autoMockOff();
-const { defineTest } = require('jscodeshift/dist/testUtils');
+import { defineTest } from 'jscodeshift/dist/testUtils';
 
 defineTest(__dirname, 'block-to-width-100', { quote: 'single' }, 'block-to-width-100', { parser: 'tsx' });

--- a/src/codemods/__tests__/colors-to-css-vars-test.ts
+++ b/src/codemods/__tests__/colors-to-css-vars-test.ts
@@ -1,5 +1,5 @@
 jest.autoMockOff();
-const { defineTest } = require('jscodeshift/dist/testUtils');
+import { defineTest } from 'jscodeshift/dist/testUtils';
 
 const tests = [
     'color-in-JSX-multi-import',

--- a/src/codemods/__tests__/deprecated-icons-test.ts
+++ b/src/codemods/__tests__/deprecated-icons-test.ts
@@ -1,5 +1,5 @@
 jest.autoMockOff();
-const { defineTest } = require('jscodeshift/dist/testUtils');
+import { defineTest } from 'jscodeshift/dist/testUtils';
 
 const tests = ['jsx-usage-single-import', 'jsx-usage-multi-import', 'styled-usage', 'constant-usage'];
 

--- a/src/codemods/__tests__/tooltip-placement-test.ts
+++ b/src/codemods/__tests__/tooltip-placement-test.ts
@@ -1,5 +1,5 @@
 jest.autoMockOff();
-const { defineTest } = require('jscodeshift/dist/testUtils');
+import { defineTest } from 'jscodeshift/dist/testUtils';
 
 const tests = ['basic-usage', 'no-placement', 'multi-usage', 'local-rename'];
 

--- a/src/codemods/__tests__/weak-to-secondary-test.ts
+++ b/src/codemods/__tests__/weak-to-secondary-test.ts
@@ -1,5 +1,5 @@
 jest.autoMockOff();
-const { defineTest } = require('jscodeshift/dist/testUtils');
+import { defineTest } from 'jscodeshift/dist/testUtils';
 
 const tests = ['basic-usage', 'local-rename', 'boolean-true', 'boolean-false', 'dynamic-value'];
 


### PR DESCRIPTION
**What:**

Use ES modules in codemods tests instead of CommonJS
​
**Why:**

The codemods tests were using CommonJS modules without any export, if I'm not wrong this makes the file not act as a module but as part of the global scope, since we had the same import in each file to test `jscodeshift` codemods they ended up conflicting with one another (see media section).

​
**How:**

- Replace `require` for `import` in each codemod test file

​
**Media:**

The issue: 

![image](https://github.com/freenowtech/wave/assets/46452321/b8c4658c-713b-4924-9038-49a19609cf6e)
You can check the entire [job log](https://github.com/freenowtech/wave/actions/runs/6378675053/job/17309726510?pr=383) if you prefer

**Checklist:**

-   [x] Ready to be merged