### PR TITLE
Make prettier ignore codemods fixtures

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package-lock.json
+src/codemods/__testfixtures__/


### PR DESCRIPTION
**What:**

Makes prettier ignore codemods fixtures

​
**Why:**

For each codemod test there are 2 fixture files, an `*.input.tsx` and an `*.output.tsx`, the test executes the codemod against the input file and compares the result with the output file, it only succeeds when they match. Since codemods are not expected to format the result code for you (since every project has different code styles) in case we format the input or the output files they could stop matching and provoke a failing test.

​
**How:**

- Add the path to the codemods fixtures in `.prettierignore`

​
**Checklist:**

-   [x] Ready to be merged
