### PR TITLE
Correct forwarded refs

### DIFF
--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { useDatepicker, MonthType, UseDatepickerProps } from '@datepicker-react/hooks';
 import styled from 'styled-components';
 
@@ -53,63 +53,60 @@ interface DatepickerProps extends UseDatepickerProps {
     locale: Locale;
 }
 
-export const Datepicker = React.forwardRef<HTMLDivElement, DatepickerProps>(
-    ({ focusedInput, locale, ...datepickerProps }, ref) => {
-        const {
-            firstDayOfWeek,
-            activeMonths,
-            isDateSelected,
-            isDateHovered,
-            isFirstOrLastSelectedDate,
-            isDateBlocked,
-            isDateFocused,
-            focusedDate,
-            onDateHover,
-            onDateSelect,
-            onDateFocus,
-            goToPreviousMonths,
-            goToNextMonths
-        } = useDatepicker({
-            focusedInput,
-            ...datepickerProps
-        });
+export const Datepicker: FC<DatepickerProps> = ({ focusedInput, locale, ...datepickerProps }) => {
+    const {
+        firstDayOfWeek,
+        activeMonths,
+        isDateSelected,
+        isDateHovered,
+        isFirstOrLastSelectedDate,
+        isDateBlocked,
+        isDateFocused,
+        focusedDate,
+        onDateHover,
+        onDateSelect,
+        onDateFocus,
+        goToPreviousMonths,
+        goToNextMonths
+    } = useDatepicker({
+        focusedInput,
+        ...datepickerProps
+    });
 
-        return (
-            <DatepickerContext.Provider
-                value={{
-                    focusedDate,
-                    isDateFocused,
-                    isDateSelected,
-                    isDateHovered,
-                    isDateBlocked,
-                    isFirstOrLastSelectedDate,
-                    onDateSelect,
-                    onDateFocus,
-                    onDateHover
+    return (
+        <DatepickerContext.Provider
+            value={{
+                focusedDate,
+                isDateFocused,
+                isDateSelected,
+                isDateHovered,
+                isDateBlocked,
+                isFirstOrLastSelectedDate,
+                onDateSelect,
+                onDateFocus,
+                onDateHover
+            }}
+        >
+            <DatepickerContainer
+                onMouseDown={e => {
+                    // Prevent mousedown event on Datepicker, so everything else dont lose focus
+                    e.preventDefault();
                 }}
             >
-                <DatepickerContainer
-                    ref={ref}
-                    onMouseDown={e => {
-                        // Prevent mousedown event on Datepicker, so everything else dont lose focus
-                        e.preventDefault();
-                    }}
-                >
-                    <Back onClick={goToPreviousMonths} />
-                    <Forward onClick={goToNextMonths} />
-                    <DatepickerWrapper activeMonths={activeMonths}>
-                        {activeMonths.map(monthInformation => (
-                            <Month
-                                key={`${monthInformation.year}-${monthInformation.month}`}
-                                year={monthInformation.year}
-                                month={monthInformation.month}
-                                firstDayOfWeek={firstDayOfWeek}
-                                locale={locale}
-                            />
-                        ))}
-                    </DatepickerWrapper>
-                </DatepickerContainer>
-            </DatepickerContext.Provider>
-        );
-    }
-);
+                <Back onClick={goToPreviousMonths} />
+                <Forward onClick={goToNextMonths} />
+                <DatepickerWrapper activeMonths={activeMonths}>
+                    {activeMonths.map(monthInformation => (
+                        <Month
+                            key={`${monthInformation.year}-${monthInformation.month}`}
+                            year={monthInformation.year}
+                            month={monthInformation.month}
+                            firstDayOfWeek={firstDayOfWeek}
+                            locale={locale}
+                        />
+                    ))}
+                </DatepickerWrapper>
+            </DatepickerContainer>
+        </DatepickerContext.Provider>
+    );
+};

--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -1,4 +1,4 @@
-import React, { FC, RefObject } from 'react';
+import React from 'react';
 import { useDatepicker, MonthType, UseDatepickerProps } from '@datepicker-react/hooks';
 import styled from 'styled-components';
 
@@ -49,72 +49,67 @@ const Forward = styled(ChevronRightIcon)`
     }
 `;
 
-interface BaseDatepickerProps extends UseDatepickerProps {
-    forwardedRef: RefObject<HTMLDivElement>;
+interface DatepickerProps extends UseDatepickerProps {
     locale: Locale;
 }
 
-const BaseDatepicker: FC<BaseDatepickerProps> = ({ forwardedRef, focusedInput, locale, ...datepickerProps }) => {
-    const {
-        firstDayOfWeek,
-        activeMonths,
-        isDateSelected,
-        isDateHovered,
-        isFirstOrLastSelectedDate,
-        isDateBlocked,
-        isDateFocused,
-        focusedDate,
-        onDateHover,
-        onDateSelect,
-        onDateFocus,
-        goToPreviousMonths,
-        goToNextMonths
-    } = useDatepicker({
-        focusedInput,
-        ...datepickerProps
-    });
+export const Datepicker = React.forwardRef<HTMLDivElement, DatepickerProps>(
+    ({ focusedInput, locale, ...datepickerProps }, ref) => {
+        const {
+            firstDayOfWeek,
+            activeMonths,
+            isDateSelected,
+            isDateHovered,
+            isFirstOrLastSelectedDate,
+            isDateBlocked,
+            isDateFocused,
+            focusedDate,
+            onDateHover,
+            onDateSelect,
+            onDateFocus,
+            goToPreviousMonths,
+            goToNextMonths
+        } = useDatepicker({
+            focusedInput,
+            ...datepickerProps
+        });
 
-    return (
-        <DatepickerContext.Provider
-            value={{
-                focusedDate,
-                isDateFocused,
-                isDateSelected,
-                isDateHovered,
-                isDateBlocked,
-                isFirstOrLastSelectedDate,
-                onDateSelect,
-                onDateFocus,
-                onDateHover
-            }}
-        >
-            <DatepickerContainer
-                ref={forwardedRef}
-                onMouseDown={e => {
-                    // Prevent mousedown event on Datepicker, so everything else dont lose focus
-                    e.preventDefault();
+        return (
+            <DatepickerContext.Provider
+                value={{
+                    focusedDate,
+                    isDateFocused,
+                    isDateSelected,
+                    isDateHovered,
+                    isDateBlocked,
+                    isFirstOrLastSelectedDate,
+                    onDateSelect,
+                    onDateFocus,
+                    onDateHover
                 }}
             >
-                <Back onClick={goToPreviousMonths} />
-                <Forward onClick={goToNextMonths} />
-                <DatepickerWrapper activeMonths={activeMonths}>
-                    {activeMonths.map(monthInformation => (
-                        <Month
-                            key={`${monthInformation.year}-${monthInformation.month}`}
-                            year={monthInformation.year}
-                            month={monthInformation.month}
-                            firstDayOfWeek={firstDayOfWeek}
-                            locale={locale}
-                        />
-                    ))}
-                </DatepickerWrapper>
-            </DatepickerContainer>
-        </DatepickerContext.Provider>
-    );
-};
-
-export const Datepicker = React.forwardRef(
-    (props: Omit<BaseDatepickerProps, 'forwardedRef'>, ref: RefObject<HTMLDivElement>) => (
-        <BaseDatepicker {...props} forwardedRef={ref} />
-    )
+                <DatepickerContainer
+                    ref={ref}
+                    onMouseDown={e => {
+                        // Prevent mousedown event on Datepicker, so everything else dont lose focus
+                        e.preventDefault();
+                    }}
+                >
+                    <Back onClick={goToPreviousMonths} />
+                    <Forward onClick={goToNextMonths} />
+                    <DatepickerWrapper activeMonths={activeMonths}>
+                        {activeMonths.map(monthInformation => (
+                            <Month
+                                key={`${monthInformation.year}-${monthInformation.month}`}
+                                year={monthInformation.year}
+                                month={monthInformation.month}
+                                firstDayOfWeek={firstDayOfWeek}
+                                locale={locale}
+                            />
+                        ))}
+                    </DatepickerWrapper>
+                </DatepickerContainer>
+            </DatepickerContext.Provider>
+        );
+    }
 );

--- a/src/components/Datepicker/DatepickerRangeInput.tsx
+++ b/src/components/Datepicker/DatepickerRangeInput.tsx
@@ -296,20 +296,12 @@ const DatepickerRangeInput: FC<DatepickerRangeInputProps> = ({
 
         switch (focusedInput) {
             case START_DATE: {
-                const startInputTarget = startDateRef.current && (startDateRef.current.children[0] as HTMLInputElement);
-
-                if (startInputTarget) {
-                    startInputTarget.focus();
-                }
+                if (startDateRef?.current) startDateRef.current.focus();
 
                 break;
             }
             case END_DATE: {
-                const endInputTarget = endDateRef.current && (endDateRef.current.children[0] as HTMLInputElement);
-
-                if (endInputTarget) {
-                    endInputTarget.focus();
-                }
+                if (endDateRef?.current) endDateRef.current.focus();
 
                 break;
             }

--- a/src/components/Datepicker/DatepickerRangeInput.tsx
+++ b/src/components/Datepicker/DatepickerRangeInput.tsx
@@ -239,7 +239,7 @@ const DatepickerRangeInput: FC<DatepickerRangeInputProps> = ({
     variant = 'normal',
     disabled,
     ...rest
-}: DatepickerRangeInputProps) => {
+}) => {
     const [triggerReference, setTriggerReference] = useState(undefined);
     const [contentReference, setContentReference] = useState(undefined);
     const [arrowReference, setArrowReference] = useState(undefined);

--- a/src/components/Datepicker/DatepickerSingleInput.tsx
+++ b/src/components/Datepicker/DatepickerSingleInput.tsx
@@ -1,6 +1,6 @@
 import { FirstDayOfWeek, START_DATE } from '@datepicker-react/hooks';
 import parse from 'date-fns/parse';
-import React, { ChangeEventHandler, FC, useEffect, useRef, useState } from 'react';
+import React, { ChangeEventHandler, FC, useEffect, useState } from 'react';
 import { MarginProps, WidthProps } from 'styled-system';
 import { usePopper } from 'react-popper';
 import { createPortal } from 'react-dom';
@@ -94,13 +94,12 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
     inputId,
     disabled,
     ...rest
-}: DatepickerSingleInputProps) => {
+}) => {
     const [triggerReference, setTriggerReference] = useState(undefined);
     const [contentReference, setContentReference] = useState(undefined);
     const [arrowReference, setArrowReference] = useState(undefined);
 
     const localeObject = useLocaleObject(locale);
-    const inputRef = useRef<HTMLDivElement>();
     const [isFocused, setIsFocused] = useState(false);
     const [inputText, setInputText] = useState(dateToDisplayText(localeObject, displayFormat, value));
     const [error, setError] = useState(false);
@@ -172,7 +171,6 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
             <Input
                 ref={element => {
                     setTriggerReference(element);
-                    inputRef.current = element;
                 }}
                 id={id}
                 autoComplete="off"

--- a/src/components/Input/InnerInput.tsx
+++ b/src/components/Input/InnerInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { extractClassNameProps, extractWidthProps, extractWrapperMarginProps } from '../../utils/extractProps';
 import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 import { BottomLinedInput } from './BottomLinedInput';
@@ -8,19 +8,20 @@ import { BoxedInputLabel } from './BoxedInputLabel';
 import { InputProps } from './InputProps';
 import { InputWrapper, InputWrapperProps } from './InputWrapper';
 
-const InnerInput = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>(
+const InnerInput = forwardRef<HTMLInputElement, InputWrapperProps & InputProps>(
     (props: InputWrapperProps & InputProps, ref) => {
         const { classNameProps, restProps: withoutClassName } = extractClassNameProps(props);
         const { marginProps, restProps: withoutMargin } = extractWrapperMarginProps(withoutClassName);
         const { widthProps, restProps } = extractWidthProps(withoutMargin);
-        // TODO replace with ref when implementing https://github.com/freenowtech/wave/issues/169
-        const inputRef = useRef<HTMLInputElement>();
 
         const { label, onChange, size, id: providedId, variant, ...rest } = restProps;
         const id = useGeneratedId(providedId);
 
+        const innerRef = useRef<HTMLInputElement>();
+        useImperativeHandle(ref, () => innerRef.current, []);
+
         const [hasValue, setHasValue] = useState(rest?.value?.toString().length > 0);
-        const hasUncontrolledValue = inputRef?.current?.value?.length > 0;
+        const hasUncontrolledValue = innerRef?.current?.value?.length > 0;
 
         const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
             setHasValue(event.target.value.length > 0);
@@ -38,7 +39,7 @@ const InnerInput = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>(
                 <InputWrapper ref={ref} {...classNameProps} {...marginProps} {...widthProps}>
                     <BoxedInput
                         {...rest}
-                        ref={inputRef}
+                        ref={innerRef}
                         variant={variant}
                         id={id}
                         size={size}

--- a/src/components/Input/InnerInput.tsx
+++ b/src/components/Input/InnerInput.tsx
@@ -36,7 +36,7 @@ const InnerInput = forwardRef<HTMLInputElement, InputWrapperProps & InputProps>(
 
         if (variant === 'boxed') {
             return (
-                <InputWrapper ref={ref} {...classNameProps} {...marginProps} {...widthProps}>
+                <InputWrapper {...classNameProps} {...marginProps} {...widthProps}>
                     <BoxedInput
                         {...rest}
                         ref={innerRef}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -5,7 +5,7 @@ import { InputProps } from './InputProps';
 import { InputWrapperProps } from './InputWrapper';
 import { InnerInput } from './InnerInput';
 
-const Input = forwardRef<HTMLDivElement, InputWrapperProps & InputProps>(
+const Input = forwardRef<HTMLInputElement, InputWrapperProps & InputProps>(
     (props: InputWrapperProps & InputProps, ref) => {
         if (props.type === 'password') {
             return <Password {...props} ref={ref} />;

--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -106,7 +106,7 @@ const Password = forwardRef<HTMLInputElement, PasswordProps>(
                     variant={variant}
                     inverted={inverted}
                     disabled={disabled}
-                    ref={ref}
+                    ref={inputRef}
                     type={isHidden ? 'password' : 'text'}
                     autoComplete={purpose === 'new-password' ? 'new-password' : 'off'}
                 />
@@ -118,7 +118,7 @@ const Password = forwardRef<HTMLInputElement, PasswordProps>(
                             type="button"
                             onClick={() => {
                                 setIsHidden(prevValue => !prevValue);
-                                inputRef?.current.focus();
+                                if (inputRef?.current) inputRef.current.focus();
                             }}
                             aria-controls={inputId}
                             aria-label={isHidden ? aria.showPasswordButton : aria.hidePasswordButton}

--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system';
@@ -69,7 +69,7 @@ declare module 'csstype' {
     }
 }
 
-const Password = forwardRef<HTMLDivElement, PasswordProps>(
+const Password = forwardRef<HTMLInputElement, PasswordProps>(
     (
         {
             purpose = 'login',
@@ -93,6 +93,9 @@ const Password = forwardRef<HTMLDivElement, PasswordProps>(
         const { marginProps, restProps: withoutMargin } = extractWrapperMarginProps(rest);
         const { widthProps, restProps } = extractWidthProps(withoutMargin);
 
+        const inputRef = useRef<HTMLInputElement>();
+        useImperativeHandle(ref, () => inputRef.current, []);
+
         return (
             <PasswordWrapper {...widthProps} {...marginProps}>
                 <Input
@@ -115,13 +118,7 @@ const Password = forwardRef<HTMLDivElement, PasswordProps>(
                             type="button"
                             onClick={() => {
                                 setIsHidden(prevValue => !prevValue);
-
-                                // TODO use ref passed to the input once https://github.com/freenowtech/wave/issues/169 is solved
-                                // set input focus
-                                const inputElement: HTMLElement = document.querySelector(`input[id=${inputId}]`);
-                                if (inputElement) {
-                                    inputElement.focus();
-                                }
+                                inputRef?.current.focus();
                             }}
                             aria-controls={inputId}
                             aria-label={isHidden ? aria.showPasswordButton : aria.hidePasswordButton}

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
 import {
     compose,
@@ -79,8 +79,8 @@ const PhoneInput: React.FC<PhoneInputProps> = ({
 }: PhoneInputProps) => {
     const { marginProps } = extractWrapperMarginProps(props);
 
-    const nationalNumberInputRef = React.createRef<HTMLInputElement>();
-    const containerRef = React.createRef<HTMLDivElement>();
+    const nationalNumberInputRef = useRef<HTMLInputElement>();
+    const containerRef = useRef<HTMLDivElement>();
     const spaceBetweenInputs = variant === 'boxed' ? '0.25rem' : '0.75rem';
 
     const handleCountrySelection = value => {
@@ -88,7 +88,7 @@ const PhoneInput: React.FC<PhoneInputProps> = ({
             props.onCountryChange(value);
         }
 
-        nationalNumberInputRef.current.focus();
+        if (nationalNumberInputRef?.current) nationalNumberInputRef.current.focus();
     };
 
     return (

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -79,7 +79,7 @@ const PhoneInput: React.FC<PhoneInputProps> = ({
 }: PhoneInputProps) => {
     const { marginProps } = extractWrapperMarginProps(props);
 
-    const nationalNumberInputRef = React.createRef<HTMLDivElement>();
+    const nationalNumberInputRef = React.createRef<HTMLInputElement>();
     const containerRef = React.createRef<HTMLDivElement>();
     const spaceBetweenInputs = variant === 'boxed' ? '0.25rem' : '0.75rem';
 
@@ -88,7 +88,7 @@ const PhoneInput: React.FC<PhoneInputProps> = ({
             props.onCountryChange(value);
         }
 
-        (nationalNumberInputRef.current.children[0] as HTMLInputElement).focus();
+        nationalNumberInputRef.current.focus();
     };
 
     return (


### PR DESCRIPTION
**What:**

Make refs point to the most obvious element in `Input` and `Password` components and correct refs usages in our components. Apart from that I've also removed the `forwardRef` from our internal `Datepicker` component since it wasn't being used (this is not a component exposed by Wave, it's used internally by `DatepickerSingleInput` and `DatepickerRangeInput`)

​
**Why:**

To correct our usages of refs so that it follows [our agreement](https://github.com/freenowtech/wave/issues/156#issuecomment-880546292).

​
**How:**

- Correct ref type in `Input`, `Password` and `InnerInput` to `HTMLInputElement`
- Correct the ref in `InnerInput` so it's passed to the input instead of to the wrapper
- Adapt `DatepickerRangeInput` to use the new `Input` ref
- Adapt `PhoneInput` to use the new `Input` ref
- Remove `forwardRef` from `Datepicker`

​
**Other:**

After this PR we are only forwarding refs in 3 places in the codebase:
- `Input` and `Password` components (external components that our users can use)
- `InnerInput` component (internal component that we don't expose, needed for `Input` and `Password`)

Since the ref in the `Datepicker` (internal) was not being used in either of it's parents (the actual `Datepicker` and `DatepickerRangeInput` components that we expose) there was no way for a project to depend on this ref, so I've decided to remove it. Even if in the future we decide to have a ref/refs in `Datepicker` it will point to a different element, since the one removed did not follow our agreement on refs.

**Checklist:**

- [x] Check ref in internal `Datepicker` 
- [x] Ready to be merged


Closes #169 
