### PR TITLE
fix: enhanced breadcrumbs style

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,14 @@
-import React, { Children, ComponentPropsWithoutRef, ReactElement, ReactNode, cloneElement } from 'react';
+import React, {
+    Children,
+    ComponentPropsWithoutRef,
+    ReactElement,
+    ReactNode,
+    cloneElement,
+    useEffect,
+    useRef
+} from 'react';
 import styled from 'styled-components';
+import { MarginProps } from 'styled-system';
 
 import { ChevronRightIcon } from '../../icons';
 import { Text } from '../Text/Text';
@@ -17,7 +26,7 @@ interface InvertedStyle {
     inverted?: boolean;
 }
 
-interface BreadcrumbsProps extends InvertedStyle {
+interface BreadcrumbsProps extends InvertedStyle, MarginProps {
     /**
      * Content of the Breadcrumbs
      * @required
@@ -33,17 +42,31 @@ const BreadcrumbsList = styled.ul`
     padding: 0;
     list-style: none;
     display: flex;
+    overflow: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        width: 0rem;
+    }
 `;
 
 const BreadcrumbsListItem = styled.li`
     display: flex;
+    text-wrap: nowrap;
 `;
 
 const Breadcrumbs = ({ children, inverted }: BreadcrumbsProps): JSX.Element => {
     const arrayChildren = Children.toArray(children);
+    const breadcrumbsListRef = useRef<HTMLUListElement | null>(null);
+
+    useEffect(() => {
+        if (breadcrumbsListRef.current) {
+            breadcrumbsListRef.current.scrollLeft = breadcrumbsListRef.current.scrollWidth;
+        }
+    }, []);
 
     return (
-        <BreadcrumbsList>
+        <BreadcrumbsList ref={breadcrumbsListRef}>
             {Children.map(arrayChildren, (child, index) => (
                 <BreadcrumbsListItem>
                     <nav aria-label="breadcrumbs">

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -46,7 +46,7 @@ const BreadcrumbsList = styled.ul`
     scrollbar-width: none;
 
     &::-webkit-scrollbar {
-        width: 0rem;
+        width: 0;
     }
 `;
 


### PR DESCRIPTION
###  **What:**
enhance breadcrumbs style:
- nowrap when is longer than the container
- accept margin props
- scroll right if it's longer than the container
​
###  **Why:**
The design was not ideal breaking every word and going to a new line.
​
###  **How:**
- adjust the style of the `ul` and `li`s
- use the ref to change the scroll
​
### **Media:**

**Before** 
<img width="347" alt="Screenshot 2023-10-10 at 16 48 17" src="https://github.com/freenowtech/wave/assets/12762609/346ea9b4-9977-4614-b302-e2c788809604">

**After** 
<video width="347" alt="Screenshot 2023-10-10 at 16 48 17" src="https://github.com/freenowtech/wave/assets/12762609/553615a5-98f4-4fc4-9106-e7e7f1c44623"> 

