### PR TITLE
fix: allow to overwrite attrs in InfoBannerCard

### DIFF
--- a/src/components/InfoBanner/blocks/InfoBannerCard.tsx
+++ b/src/components/InfoBanner/blocks/InfoBannerCard.tsx
@@ -14,15 +14,21 @@ interface CardProps extends BoxProps {
     emphasized?: boolean;
 }
 
-const StyledTitle = styled(Headline).attrs({ as: 'h4', textAlign: 'left' })`
+const StyledTitle = styled(Headline).attrs(props => ({ as: 'h4', textAlign: 'left', ...props }))`
     color: var(--info-banner-text-color);
 `;
 
-const StyledDescription = styled(Text).attrs({ fontSize: 'small', textAlign: 'left' })`
+const StyledDescription = styled(Text).attrs(props => ({ fontSize: 'small', textAlign: 'left', ...props }))`
     color: var(--info-banner-text-color);
 `;
 
-const StyledLink = styled(WaveLink).attrs({ fontSize: 0, textAlign: 'left', target: '_blank', marginTop: '0.25rem' })`
+const StyledLink = styled(WaveLink).attrs(props => ({
+    fontSize: 0,
+    textAlign: 'left',
+    target: '_blank',
+    marginTop: '0.25rem',
+    ...props
+}))`
     &:link,
     &:visited {
         color: var(--info-banner-link-color);


### PR DESCRIPTION
**What:**

Allow to overwrite the `attrs` set in `InfoBanner` compound component (`InfoBannerCard`)

​
**Why:**

With the compound approach we want to bring to our users freedom to compose their own version of our components, therefore we should allow them to overwrite our preset attributes.

​
**How:**

Overwrite attributes in `.attrs` with the passed props in all `InfoBannerCard` blocks

**Explanation**
In styled-components the precedence of passed "attributes" to a component is [`attrs` > `props` > `defaultProps`](https://github.com/styled-components/styled-components/issues/2372#issuecomment-570291654), meaning that `attrs` overwrites everything.

Before we had our `InfoBannerCard.Link` as

```tsx
const StyledLink = styled(WaveLink).attrs({ fontSize: 0, textAlign: 'left', target: '_blank', marginTop: '0.25rem' })`...`
```

which meant that those attributes could not be overwritten.

By passing a function to `attrs` we can receive the props as an argument and overwrite our attributes with them, just like 

```tsx
.attrs(props => ({
    fontSize: 0,
    textAlign: 'left',
    target: '_blank',
    marginTop: '0.25rem',
    ...props
}))
```
​
You can check the current precedence in [this codesandbox](https://codesandbox.io/s/wave-inforbanner-target-self-5fvd5g?file=/src/App.js)

**Checklist:**

-   [x] Ready to be merged


Closes #391 