### PR TITLE
Describes the new `Text` component behaviour

### DIFF
--- a/docs/migrating.storybook.mdx
+++ b/docs/migrating.storybook.mdx
@@ -200,6 +200,26 @@ Codemod to automatically migrate `SemanticColors`:
 npx jscodeshift --parser=tsx --extension=js,jsx,ts,tsx -t node_modules/@freenow/wave/lib/cjs/codemods/semantic-colors-to-new-theme.js path/to/src
 ```
 
+### `Text` and icons inherit font color from container
+
+The `Text` component and all icon components will now inherit font color from their parent container,
+replacing the previous hardcoded font colors.
+
+If you want to enforce the primary color, a new `primary` prop has been introduced for the `Text` component.
+
+```jsx
+import { Box, Text } from '@freenow/wave';
+
+const Card = () => {
+    return (
+        <Box color="pink">
+            <Text>Pink glasses!</Text>
+            <Text primary>Primary black text</Text>
+        </Box>
+    );
+};
+```
+
 ### `inverted` prop is removed
 
 With the introduction of our new dark scheme in Wave, we've removed the `inverted` property

--- a/src/components/Text/docs/Text.storybook.mdx
+++ b/src/components/Text/docs/Text.storybook.mdx
@@ -18,7 +18,9 @@ The Text component is a wrapper component that will apply typography styles to t
 ## Usage
 
 By default, `Text` uses the color of the container, which is the primary color in most of the cases.
-This approach allows the component to adapt to the container needs. Use the `primary` property in order to force the primary color of the theme.
+This approach allows the component to adapt to the container needs.
+
+Use the `primary` property to show text in the primary color of the theme, overriding the container font color.
 
 Use the `secondary` color for supplemental information with diminished contrast (often, the “gray text”).
 Like form microcopy, captions, helper text, and other medium emphasized text elements.


### PR DESCRIPTION
<!--
Thanks for your interest in the project!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

Describes that `Text` now inherits the colour of the container.

## Why

I observed how other engineers migrated to Wave 2.0 and noticed they were surprised by this behaviour. I think it is worth highlighting in the migration guide
​