### PR TITLE
docs: fix semantic colors hsl values in colors table

### DIFF
--- a/src/essentials/Colors/Colors.ts
+++ b/src/essentials/Colors/Colors.ts
@@ -63,27 +63,27 @@ export const SemanticColors = {
     transparent: Colors.transparent,
     foreground: {
         primary: Colors.blue.primary[900],
-        'on-background': {
-            primary: Colors.white,
-            accent: Colors.white,
-            info: Colors.white,
-            success: Colors.white,
-            warning: Colors.blue.primary[900],
-            danger: Colors.white,
-            disabled: Colors.white,
-            neutral: Colors.blue.primary[900]
+        accent: {
+            default: Colors.blue.secondary[900],
+            emphasized: Colors.blue.secondary[1000]
         },
-        disabled: Colors.blue.primary[200],
-        focus: Colors.blue.secondary[900],
         neutral: {
             faded: Colors.blue.primary[200],
             default: Colors.blue.primary[350],
             emphasized: Colors.blue.primary[550]
         },
-        accent: {
-            default: Colors.blue.secondary[900],
-            emphasized: Colors.blue.secondary[1000]
+        'on-background': {
+            primary: Colors.white,
+            accent: Colors.white,
+            neutral: Colors.blue.primary[900],
+            disabled: Colors.white,
+            info: Colors.white,
+            success: Colors.white,
+            warning: Colors.blue.primary[900],
+            danger: Colors.white
         },
+        disabled: Colors.blue.primary[200],
+        focus: Colors.blue.secondary[900],
         info: {
             faded: Colors.blue.secondary[900],
             default: Colors.blue.secondary[900]
@@ -107,13 +107,13 @@ export const SemanticColors = {
             'elevation-3': Colors.white
         },
         element: {
-            disabled: {
-                faded: Colors.blue.primary[50],
-                default: Colors.blue.primary[200]
-            },
             primary: {
                 default: Colors.blue.primary[900],
                 emphasized: Colors.blue.primary[1100]
+            },
+            disabled: {
+                faded: Colors.blue.primary[50],
+                default: Colors.blue.primary[200]
             },
             neutral: {
                 default: Colors.white,
@@ -173,17 +173,17 @@ export const SemanticColors = {
         backdrop: Colors.blue.primary[900]
     },
     border: {
+        accent: {
+            faded: Colors.blue.secondary[350],
+            default: Colors.blue.secondary[900]
+        },
         neutral: {
             faded: Colors.white,
             default: Colors.blue.primary[200],
             emphasized: Colors.blue.primary[550]
         },
-        accent: {
-            faded: Colors.blue.secondary[350],
-            default: Colors.blue.secondary[900]
-        },
-        focus: Colors.blue.secondary[900],
         disabled: Colors.blue.primary[200],
+        focus: Colors.blue.secondary[900],
         info: {
             banner: Colors.blue.secondary[350],
             faded: Colors.blue.secondary[350],
@@ -231,12 +231,12 @@ export const SemanticColorsDarkSchema = {
         },
         'on-background': {
             primary: Colors.blue.secondary[900],
-            disabled: Colors.blue.primary[350],
-            success: Colors.white,
             accent: Colors.white,
             neutral: Colors.blue.primary[900],
-            warning: Colors.blue.primary[900],
+            disabled: Colors.blue.primary[350],
             info: Colors.white,
+            success: Colors.white,
+            warning: Colors.blue.primary[900],
             danger: Colors.white
         },
         disabled: Colors.blue.primary[350],
@@ -268,22 +268,22 @@ export const SemanticColorsDarkSchema = {
                 default: Colors.white,
                 emphasized: Colors.blue.secondary[900]
             },
-            disabled: {
-                faded: Colors.blue.primary[750],
-                default: Colors.blue.primary[550]
-            },
             accent: {
                 faded: Colors.blue.secondary[1000],
                 default: Colors.blue.secondary[900],
                 emphasized: Colors.blue.secondary[900]
             },
-            info: {
-                default: Colors.blue.secondary[900],
-                emphasized: Colors.blue.secondary[1000]
+            disabled: {
+                faded: Colors.blue.primary[750],
+                default: Colors.blue.primary[550]
             },
             neutral: {
                 default: Colors.blue.primary[350],
                 emphasized: Colors.white
+            },
+            info: {
+                default: Colors.blue.secondary[900],
+                emphasized: Colors.blue.secondary[1000]
             },
             success: {
                 default: Colors.green[50]
@@ -330,15 +330,17 @@ export const SemanticColorsDarkSchema = {
         backdrop: Colors.blue.primary[50]
     },
     border: {
+        accent: {
+            faded: Colors.blue.secondary[350],
+            default: Colors.blue.secondary[350]
+        },
         neutral: {
             faded: Colors.white,
             default: Colors.white,
             emphasized: Colors.blue.primary[550]
         },
-        accent: {
-            faded: Colors.blue.secondary[350],
-            default: Colors.blue.secondary[350]
-        },
+        disabled: Colors.blue.primary[550],
+        focus: Colors.blue.secondary[900],
         info: {
             banner: Colors.blue.secondary[350],
             default: Colors.blue.secondary[900],
@@ -357,9 +359,7 @@ export const SemanticColorsDarkSchema = {
             banner: Colors.orange[350],
             faded: Colors.orange[900],
             default: Colors.orange[900]
-        },
-        focus: Colors.blue.secondary[900],
-        disabled: Colors.blue.primary[550]
+        }
     },
     logo: {
         free: 'hsl(350, 91%, 41%)',

--- a/src/essentials/Colors/ModernColors.ts
+++ b/src/essentials/Colors/ModernColors.ts
@@ -262,6 +262,11 @@ export const SemanticColorsDarkSchema = {
                 default: Colors.neutral[50],
                 emphasized: Colors.white
             },
+            accent: {
+                faded: Colors.primary[1000],
+                default: Colors.primary[900],
+                emphasized: Colors.primary[350]
+            },
             disabled: {
                 faded: Colors.neutral[650],
                 default: Colors.neutral[550]
@@ -269,11 +274,6 @@ export const SemanticColorsDarkSchema = {
             neutral: {
                 default: Colors.neutral[350],
                 emphasized: Colors.white
-            },
-            accent: {
-                faded: Colors.primary[1000],
-                default: Colors.primary[900],
-                emphasized: Colors.primary[350]
             },
             info: {
                 default: Colors.neutral[350],

--- a/src/essentials/Colors/ModernColors.ts
+++ b/src/essentials/Colors/ModernColors.ts
@@ -56,28 +56,28 @@ export const SemanticColors = {
     white: Colors.white,
     transparent: Colors.transparent,
     foreground: {
-        disabled: Colors.neutral[200],
-        focus: Colors.neutral[550],
         primary: Colors.neutral[900],
-        'on-background': {
-            primary: Colors.white,
-            accent: Colors.white,
-            info: Colors.white,
-            success: Colors.white,
-            warning: Colors.neutral[900],
-            danger: Colors.white,
-            disabled: Colors.white,
-            neutral: Colors.neutral[900]
+        accent: {
+            default: Colors.primary[900],
+            emphasized: Colors.primary[1000]
         },
         neutral: {
             faded: Colors.neutral[200],
             default: Colors.neutral[350],
             emphasized: Colors.neutral[550]
         },
-        accent: {
-            default: Colors.primary[900],
-            emphasized: Colors.primary[1000]
+        'on-background': {
+            primary: Colors.white,
+            accent: Colors.white,
+            neutral: Colors.neutral[900],
+            disabled: Colors.white,
+            info: Colors.white,
+            success: Colors.white,
+            warning: Colors.neutral[900],
+            danger: Colors.white
         },
+        disabled: Colors.neutral[200],
+        focus: Colors.neutral[550],
         info: {
             faded: Colors.neutral[550],
             default: Colors.neutral[900]
@@ -101,13 +101,13 @@ export const SemanticColors = {
             'elevation-3': Colors.white
         },
         element: {
-            disabled: {
-                faded: Colors.neutral[50],
-                default: Colors.neutral[200]
-            },
             primary: {
                 default: Colors.primary[900],
                 emphasized: Colors.primary[1000]
+            },
+            disabled: {
+                faded: Colors.neutral[50],
+                default: Colors.neutral[200]
             },
             neutral: {
                 default: Colors.white,
@@ -167,17 +167,17 @@ export const SemanticColors = {
         backdrop: Colors.neutral[900]
     },
     border: {
+        accent: {
+            faded: Colors.primary[350],
+            default: Colors.primary[900]
+        },
         neutral: {
             faded: Colors.neutral[50],
             default: Colors.neutral[200],
             emphasized: Colors.neutral[550]
         },
-        accent: {
-            faded: Colors.primary[350],
-            default: Colors.primary[900]
-        },
-        focus: Colors.neutral[550],
         disabled: Colors.neutral[200],
+        focus: Colors.neutral[550],
         info: {
             banner: Colors.neutral[200],
             faded: Colors.neutral[200],
@@ -225,12 +225,12 @@ export const SemanticColorsDarkSchema = {
         },
         'on-background': {
             primary: Colors.primary[900],
-            disabled: Colors.neutral[350],
-            success: Colors.white,
             accent: Colors.primary[900],
             neutral: Colors.neutral[900],
-            warning: Colors.neutral[900],
+            disabled: Colors.neutral[350],
             info: Colors.white,
+            success: Colors.white,
+            warning: Colors.neutral[900],
             danger: Colors.white
         },
         disabled: Colors.neutral[550],
@@ -324,17 +324,17 @@ export const SemanticColorsDarkSchema = {
         backdrop: Colors.neutral[50]
     },
     border: {
+        accent: {
+            faded: Colors.primary[350],
+            default: Colors.primary[350]
+        },
         neutral: {
             faded: Colors.neutral[50],
             default: Colors.neutral[200],
             emphasized: Colors.neutral[50]
         },
-        focus: Colors.neutral[550],
         disabled: Colors.neutral[550],
-        accent: {
-            faded: Colors.primary[350],
-            default: Colors.primary[350]
-        },
+        focus: Colors.neutral[550],
         info: {
             banner: Colors.neutral[200],
             faded: Colors.neutral[550],

--- a/src/essentials/Colors/docs/SemanticColorsTable.tsx
+++ b/src/essentials/Colors/docs/SemanticColorsTable.tsx
@@ -1,11 +1,20 @@
 import { DocsContext } from '@storybook/blocks';
 
 import React, { FC, useContext, useMemo, useState } from 'react';
+import { useDarkMode } from 'storybook-dark-mode';
 import styled from 'styled-components';
 import { Box, Input, Table, TableCell, TableHeaderCell, TableRow } from '../../../components';
 import { applyPrefix, generateCssVariableEntries, getSemanticValue } from '../../../utils/cssVariables';
-import { Colors as ClassicColors, SemanticColors as ClassicSemanticTokens } from '../Colors';
-import { Colors as ModernColors, SemanticColors as ModernSemanticTokens } from '../ModernColors';
+import {
+    Colors as ClassicColors,
+    SemanticColors as ClassicSemanticTokens,
+    SemanticColorsDarkSchema as ClassicDarkSemanticTokens
+} from '../Colors';
+import {
+    Colors as ModernColors,
+    SemanticColors as ModernSemanticTokens,
+    SemanticColorsDarkSchema as ModernDarkSemanticTokens
+} from '../ModernColors';
 
 const ColorBlock = styled.div<{ token: string }>`
     background-color: var(${p => p.token});
@@ -16,17 +25,30 @@ const ColorBlock = styled.div<{ token: string }>`
 
 const Tokens = {
     s: {
-        classic: ClassicSemanticTokens,
-        modern: ModernSemanticTokens
+        light: {
+            classic: ClassicSemanticTokens,
+            modern: ModernSemanticTokens
+        },
+        dark: {
+            classic: ClassicDarkSemanticTokens,
+            modern: ModernDarkSemanticTokens
+        }
     },
     b: {
-        classic: ClassicColors,
-        modern: ModernColors
+        light: {
+            classic: ClassicColors,
+            modern: ModernColors
+        },
+        dark: {
+            classic: ClassicColors,
+            modern: ModernColors
+        }
     }
 } as const;
 
 export const CssVariablesTable: FC<{ tier: 'b' | 's' }> = ({ tier }) => {
     const [nameSearchInput, setNameSearchInput] = useState('');
+    const isDark = useDarkMode();
     const {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -35,7 +57,7 @@ export const CssVariablesTable: FC<{ tier: 'b' | 's' }> = ({ tier }) => {
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const { theme } = globals.get();
-    const tokens = Tokens[tier][theme];
+    const tokens = Tokens[tier][isDark ? 'dark' : 'light'][theme];
 
     const entries = useMemo(() => generateCssVariableEntries(tokens), [tokens]);
     const filteredTokens = !nameSearchInput

--- a/src/essentials/Colors/docs/SemanticColorsTable.tsx
+++ b/src/essentials/Colors/docs/SemanticColorsTable.tsx
@@ -3,17 +3,7 @@ import { DocsContext } from '@storybook/blocks';
 import React, { FC, useContext, useMemo, useState } from 'react';
 import { useDarkMode } from 'storybook-dark-mode';
 import styled from 'styled-components';
-import {
-    Box,
-    DarkScheme,
-    Input,
-    InvertedColorScheme,
-    LightScheme,
-    Table,
-    TableCell,
-    TableHeaderCell,
-    TableRow
-} from '../../../components';
+import { Box, DarkScheme, Input, LightScheme, Table, TableCell, TableHeaderCell, TableRow } from '../../../components';
 import { applyPrefix, generateCssVariableEntries, getSemanticValue } from '../../../utils/cssVariables';
 import {
     Colors as ClassicColors,
@@ -26,8 +16,18 @@ import {
     SemanticColorsDarkSchema as ModernDarkSemanticTokens
 } from '../ModernColors';
 
+const CenteredTableCell = styled(TableCell)`
+    text-align: center;
+    width: 1%; // Hack to make width as small as possible while respecting table-layout: auto
+
+    &:first-child {
+        padding-left: 1rem;
+    }
+`;
+
 const BlockContainer = styled.div`
     width: 4rem;
+    margin: auto !important;
 `;
 
 const ColorBlock = styled.div<{ token: string }>`
@@ -113,13 +113,13 @@ export const CssVariablesTable: FC<{ tier: 'b' | 's' }> = ({ tier }) => {
 
                     return (
                         <TableRow key={variable}>
-                            <TableCell>
+                            <CenteredTableCell>
                                 <BlockContainer>
                                     <ColorBlock token={token} />
                                 </BlockContainer>
                                 <code>{value}</code>
-                            </TableCell>
-                            <TableCell>
+                            </CenteredTableCell>
+                            <CenteredTableCell>
                                 <BlockContainer>
                                     {isDark ? (
                                         <LightScheme>
@@ -132,7 +132,7 @@ export const CssVariablesTable: FC<{ tier: 'b' | 's' }> = ({ tier }) => {
                                     )}
                                 </BlockContainer>
                                 <code>{invertedValue}</code>
-                            </TableCell>
+                            </CenteredTableCell>
                             <TableCell>
                                 <code>{variable}</code>
                             </TableCell>

--- a/src/essentials/Colors/docs/SemanticColorsTable.tsx
+++ b/src/essentials/Colors/docs/SemanticColorsTable.tsx
@@ -18,7 +18,7 @@ import {
 
 const CenteredTableCell = styled(TableCell)`
     text-align: center;
-    width: 1%; // Hack to make width as small as possible while respecting table-layout: auto
+    width: 1%; /* Hack to make width as small as possible while respecting table-layout: auto */
 
     &:first-child {
         padding-left: 1rem;


### PR DESCRIPTION
## What

- Fixes a bug in our docs where the hsl values in the semantic colors table were not being refreshed when the light/dark theme changed.
- Make the colors table show the current scheme and the inverted scheme colors at the same time

### Media

https://github.com/freenowtech/wave/assets/46452321/be895b10-1495-4b08-8c45-225520405034

## Why

To have the correct hsl values for dark schema colors.

## How

- Point to light/dark schema object based on the colors scheme the user is viewing
- Reorder light/dark schema colors object so the order of the colors matches (so that the table order is consistent for both schemas)
- Add a column in the `CssVariablesTable` for the inverted scheme color
- Remove the `Hex Color` column in `CssVariablesTable`

Closes #419 
