### PR TITLE
ci: bump action versions to latest major

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: 18
             - name: Install dependencies
@@ -22,7 +22,7 @@ jobs:
                   install-command: npm i --legacy-peer-deps
             - name: Build docs
               run: npm run build:documentation
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: storybook-dist
                   path: storybook-static
@@ -32,7 +32,7 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: storybook-dist
                   path: public

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -13,10 +13,10 @@ jobs:
         if: github.ref != 'refs/heads/main'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   node-version: 18
             - name: Install dependencies
@@ -32,10 +32,10 @@ jobs:
         if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   node-version: 18
             - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
             - name: Merge main -> next


### PR DESCRIPTION
## What

Bump Github Actions versions to latest major

### Media

Warnings in our existing pipelines
<img width="927" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/014b71fc-a444-4820-bf9d-de6a54ebb1aa">


## Why

Node 16 has reached end of life, [Github is transitioning all Actions to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

## How

- Update all actions we are using to the latest major

### Extra
`actions-gh-pages` (used to deploy the documentation site) hasn't yet updated to Node 20, [once it does](https://github.com/peaceiris/actions-gh-pages/issues/1062) we can migrate it as well
