### PR TITLE
Fix datepicker elevation, props and bottom-lined input ref

### DIFF
--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -3,7 +3,7 @@ import { useDatepicker, MonthType, UseDatepickerProps } from '@datepicker-react/
 import styled from 'styled-components';
 
 import { getSemanticValue } from '../../utils/cssVariables';
-import { Elevation, MediaQueries } from '../../essentials';
+import { MediaQueries } from '../../essentials';
 import { ChevronLeftIcon, ChevronRightIcon } from '../../icons';
 import { Month } from './Month';
 import { DatepickerContext } from './DatepickerContext';
@@ -21,7 +21,6 @@ const DatepickerContainer = styled.div`
     display: flex;
     padding: 0.5rem;
 
-    z-index: ${Elevation.DATEPICKER};
     position: relative;
     background: ${getSemanticValue('background-surface-neutral-default')};
 

--- a/src/components/Datepicker/DatepickerContentElements.tsx
+++ b/src/components/Datepicker/DatepickerContentElements.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { Elevation } from '../../essentials';
 import { getSemanticValue } from '../../utils/cssVariables';
 
 const baseArrowStyles = css`
@@ -23,6 +24,7 @@ export const Arrow = styled.div`
 export const DatepickerContentContainer = styled.div`
     background: ${getSemanticValue('background-surface-neutral-default')};
     box-shadow: 0 0 0.5rem 0.1875rem rgba(0, 0, 0, 0.08);
+    z-index: ${Elevation.DATEPICKER};
 
     &[data-popper-placement^='top'] > ${Arrow} {
         bottom: -0.625rem;

--- a/src/components/Datepicker/DatepickerSingleInput.tsx
+++ b/src/components/Datepicker/DatepickerSingleInput.tsx
@@ -4,7 +4,7 @@ import React, { ChangeEventHandler, FC, useEffect, useState } from 'react';
 import { MarginProps, WidthProps } from 'styled-system';
 import { usePopper } from 'react-popper';
 import { createPortal } from 'react-dom';
-import { Input } from '../Input/Input';
+import { Input, InputProps } from '../Input/Input';
 
 import { Datepicker } from './Datepicker';
 import { isValidDateText } from './utils/isValidDateText';
@@ -14,15 +14,10 @@ import { dateToDisplayText } from './utils/dateToDisplayText';
 import { useLocaleObject } from './utils/useLocaleObject';
 import { Arrow, DatepickerContentContainer } from './DatepickerContentElements';
 
-interface DatepickerSingleInputProps extends MarginProps, WidthProps {
-    /**
-     * Placeholder for the input.
-     */
-    placeholder?: string;
-    /**
-     * Label for the input.
-     */
-    label?: string;
+interface DatepickerSingleInputProps
+    extends MarginProps,
+        WidthProps,
+        Omit<InputProps, 'value' | 'onChange' | 'disabled'> {
     /**
      * Function that is used when datepicker closes without selected date.
      */
@@ -85,8 +80,6 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
     isDateBlocked,
     onClose,
     onChange,
-    placeholder,
-    label,
     displayFormat = 'dd/MM/yyyy',
     locale = 'en-US',
     value,
@@ -176,8 +169,6 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
                 autoComplete="off"
                 className="startDate"
                 data-testid="start-date-input"
-                label={label}
-                placeholder={placeholder}
                 value={inputText}
                 onFocus={() => setIsFocused(true)}
                 onBlur={handleDatepickerClose}

--- a/src/components/Datepicker/docs/DatepickerOnModal.tsx
+++ b/src/components/Datepicker/docs/DatepickerOnModal.tsx
@@ -18,7 +18,7 @@ export const DatepickerOnModal: FC = () => {
                         <>
                             <Headline as="h2">New Event</Headline>
 
-                            <DatePicker value={value} onChange={setValue} />
+                            <DatePicker label="Date" value={value} onChange={setValue} />
 
                             <br />
                             <Button onClick={dismiss}>Add Event</Button>

--- a/src/components/Input/InnerInput.tsx
+++ b/src/components/Input/InnerInput.tsx
@@ -58,9 +58,10 @@ const InnerInput = forwardRef<HTMLInputElement, InputWrapperProps & InputProps>(
 
         if (variant === 'bottom-lined') {
             return (
-                <InputWrapper ref={ref} {...classNameProps} {...marginProps} {...widthProps}>
+                <InputWrapper {...classNameProps} {...marginProps} {...widthProps}>
                     <BottomLinedInput
                         {...rest}
+                        ref={innerRef}
                         variant={variant}
                         id={id}
                         waveSize={size}


### PR DESCRIPTION
## What

- Fixes Datepicker elevation when appearing on a Modal
- Fixes Datepicker props not extending Input props
- Fixes "bottom-lined" Input variant ref

### Media
Before (Datepicker underneath Modal)
<img width="669" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/99c8e431-1589-4151-aa91-64b6d48753e7">

After (Datepicker on top of Modal)
<img width="712" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/6ac0e487-89d9-4804-9d9a-785a855baf18">

## Why

To offer a consistent experience on the Datepicker and Input components

## How

- Move z-index to the highest Datepicker container (before it was in a lower level container and the Modal would take preference)
- Extend `InputProps` in `DatepickerSingleInputProps` since props are being sent to trigger `Input`
- Point ref in `InnerInput` with "bottom-lined" variant to the actual html `input` instead of the the wrapper `div`
- Minor addition of a label for the "Datepicker on Modal" story

Closes #421