### PR TITLE
Fix applied color scheme on portals

### DIFF
--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -3,7 +3,7 @@ import { useDatepicker, MonthType, UseDatepickerProps } from '@datepicker-react/
 import styled from 'styled-components';
 
 import { getSemanticValue } from '../../utils/cssVariables';
-import { Elevation, MediaQueries } from '../../essentials';
+import { MediaQueries } from '../../essentials';
 import { ChevronLeftIcon, ChevronRightIcon } from '../../icons';
 import { Month } from './Month';
 import { DatepickerContext } from './DatepickerContext';
@@ -21,7 +21,6 @@ const DatepickerContainer = styled.div`
     display: flex;
     padding: 0.5rem;
 
-    z-index: ${Elevation.DATEPICKER};
     position: relative;
     background: ${getSemanticValue('background-surface-neutral-default')};
 

--- a/src/components/Datepicker/DatepickerContentElements.tsx
+++ b/src/components/Datepicker/DatepickerContentElements.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { Elevation } from '../../essentials';
 import { getSemanticValue } from '../../utils/cssVariables';
 
 const baseArrowStyles = css`
@@ -23,6 +24,7 @@ export const Arrow = styled.div`
 export const DatepickerContentContainer = styled.div`
     background: ${getSemanticValue('background-surface-neutral-default')};
     box-shadow: 0 0 0.5rem 0.1875rem rgba(0, 0, 0, 0.08);
+    z-index: ${Elevation.DATEPICKER};
 
     &[data-popper-placement^='top'] > ${Arrow} {
         bottom: -0.625rem;

--- a/src/components/Datepicker/DatepickerRangeInput.tsx
+++ b/src/components/Datepicker/DatepickerRangeInput.tsx
@@ -1,6 +1,6 @@
 import { END_DATE, FirstDayOfWeek, FocusedInput, START_DATE } from '@datepicker-react/hooks';
 import { compareDesc, Locale, parse, startOfDay, endOfDay } from 'date-fns';
-import React, { ChangeEventHandler, FC, useEffect, useRef, useState } from 'react';
+import React, { ChangeEventHandler, FC, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system';
 import { usePopper } from 'react-popper';
@@ -19,6 +19,8 @@ import { dateToDisplayText } from './utils/dateToDisplayText';
 import { useLocaleObject } from './utils/useLocaleObject';
 import { useOnChange } from './utils/useOnChange';
 import { Arrow, DatepickerContentContainer } from './DatepickerContentElements';
+import { DarkScheme, LightScheme } from '../ColorScheme';
+import { useClosestColorScheme } from '../../utils/hooks/useClosestColorScheme';
 
 type DateRangerProps = MarginProps & WidthProps;
 
@@ -278,6 +280,7 @@ const DatepickerRangeInput: FC<DatepickerRangeInputProps> = ({
         ]
     });
 
+    const enforcedColorScheme = useClosestColorScheme(triggerReference);
     const startId = useGeneratedId(startInputId);
     const endId = useGeneratedId(endInputId);
 
@@ -364,6 +367,11 @@ const DatepickerRangeInput: FC<DatepickerRangeInputProps> = ({
         }));
     };
 
+    const PortalWrapper = useMemo(() => {
+        if (!enforcedColorScheme) return React.Fragment;
+        return enforcedColorScheme === 'light' ? LightScheme : DarkScheme;
+    }, [enforcedColorScheme]);
+
     return (
         <>
             <DateRangeWrapper ref={setTriggerReference} {...rest}>
@@ -412,26 +420,32 @@ const DatepickerRangeInput: FC<DatepickerRangeInputProps> = ({
             )}
             {focusedInput &&
                 createPortal(
-                    <DatepickerContentContainer ref={setContentReference} style={styles.popper} {...attributes.popper}>
-                        <Arrow ref={setArrowReference} style={styles.arrow} {...attributes.arrow} />
-                        <Datepicker
-                            // TODO: refer to https://stash.intapps.it/projects/DS/repos/wave/pull-requests/104/overview?commentId=168382
-                            numberOfMonths={variant === 'normal' && window.innerWidth >= 768 ? 2 : 1}
-                            minBookingDays={1}
-                            startDate={value.startDate}
-                            endDate={value.endDate}
-                            minBookingDate={minDate}
-                            maxBookingDate={maxDate}
-                            firstDayOfWeek={firstDayOfWeek}
-                            focusedInput={focusedInput}
-                            onDatesChange={({ focusedInput: focusedValue, startDate, endDate }) => {
-                                setFocusedInput(focusedValue);
-                                handleDateChange(startDate || undefined, endDate || undefined);
-                            }}
-                            isDateBlocked={isDateBlocked}
-                            locale={localeObject}
-                        />
-                    </DatepickerContentContainer>,
+                    <PortalWrapper>
+                        <DatepickerContentContainer
+                            ref={setContentReference}
+                            style={styles.popper}
+                            {...attributes.popper}
+                        >
+                            <Arrow ref={setArrowReference} style={styles.arrow} {...attributes.arrow} />
+                            <Datepicker
+                                // TODO: refer to https://stash.intapps.it/projects/DS/repos/wave/pull-requests/104/overview?commentId=168382
+                                numberOfMonths={variant === 'normal' && window.innerWidth >= 768 ? 2 : 1}
+                                minBookingDays={1}
+                                startDate={value.startDate}
+                                endDate={value.endDate}
+                                minBookingDate={minDate}
+                                maxBookingDate={maxDate}
+                                firstDayOfWeek={firstDayOfWeek}
+                                focusedInput={focusedInput}
+                                onDatesChange={({ focusedInput: focusedValue, startDate, endDate }) => {
+                                    setFocusedInput(focusedValue);
+                                    handleDateChange(startDate || undefined, endDate || undefined);
+                                }}
+                                isDateBlocked={isDateBlocked}
+                                locale={localeObject}
+                            />
+                        </DatepickerContentContainer>
+                    </PortalWrapper>,
                     document.body
                 )}
         </>

--- a/src/components/Datepicker/DatepickerRangeInput.tsx
+++ b/src/components/Datepicker/DatepickerRangeInput.tsx
@@ -1,6 +1,6 @@
 import { END_DATE, FirstDayOfWeek, FocusedInput, START_DATE } from '@datepicker-react/hooks';
 import { compareDesc, Locale, parse, startOfDay, endOfDay } from 'date-fns';
-import React, { ChangeEventHandler, FC, useEffect, useMemo, useRef, useState } from 'react';
+import React, { ChangeEventHandler, FC, Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system';
 import { usePopper } from 'react-popper';
@@ -368,7 +368,7 @@ const DatepickerRangeInput: FC<DatepickerRangeInputProps> = ({
     };
 
     const PortalWrapper = useMemo(() => {
-        if (!enforcedColorScheme) return React.Fragment;
+        if (!enforcedColorScheme) return Fragment;
         return enforcedColorScheme === 'light' ? LightScheme : DarkScheme;
     }, [enforcedColorScheme]);
 

--- a/src/components/Datepicker/DatepickerSingleInput.tsx
+++ b/src/components/Datepicker/DatepickerSingleInput.tsx
@@ -1,6 +1,6 @@
 import { FirstDayOfWeek, START_DATE } from '@datepicker-react/hooks';
 import parse from 'date-fns/parse';
-import React, { ChangeEventHandler, FC, useEffect, useState } from 'react';
+import React, { ChangeEventHandler, FC, useEffect, useMemo, useState } from 'react';
 import { MarginProps, WidthProps } from 'styled-system';
 import { usePopper } from 'react-popper';
 import { createPortal } from 'react-dom';
@@ -13,6 +13,8 @@ import { HelperText } from '../HelperText/HelperText';
 import { dateToDisplayText } from './utils/dateToDisplayText';
 import { useLocaleObject } from './utils/useLocaleObject';
 import { Arrow, DatepickerContentContainer } from './DatepickerContentElements';
+import { DarkScheme, LightScheme } from '../ColorScheme';
+import { useClosestColorScheme } from '../../utils/hooks/useClosestColorScheme';
 
 interface DatepickerSingleInputProps
     extends MarginProps,
@@ -119,6 +121,7 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
         ]
     });
 
+    const enforcedColorScheme = useClosestColorScheme(triggerReference);
     const id = useGeneratedId(inputId);
 
     useEffect(() => {
@@ -159,6 +162,11 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
         setError(hasError);
     };
 
+    const PortalWrapper = useMemo(() => {
+        if (!enforcedColorScheme) return React.Fragment;
+        return enforcedColorScheme === 'light' ? LightScheme : DarkScheme;
+    }, [enforcedColorScheme]);
+
     return (
         <>
             <Input
@@ -182,26 +190,32 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
             )}
             {isFocused &&
                 createPortal(
-                    <DatepickerContentContainer ref={setContentReference} style={styles.popper} {...attributes.popper}>
-                        <Arrow ref={setArrowReference} style={styles.arrow} {...attributes.arrow} />
-                        <Datepicker
-                            numberOfMonths={1}
-                            exactMinBookingDays
-                            minBookingDays={1}
-                            startDate={value}
-                            endDate={value}
-                            minBookingDate={minDate}
-                            maxBookingDate={maxDate}
-                            firstDayOfWeek={firstDayOfWeek}
-                            focusedInput={isFocused ? START_DATE : undefined}
-                            onDatesChange={({ focusedInput, startDate }) => {
-                                setIsFocused(focusedInput !== null);
-                                handleDateChange(startDate || undefined);
-                            }}
-                            isDateBlocked={isDateBlocked}
-                            locale={localeObject}
-                        />
-                    </DatepickerContentContainer>,
+                    <PortalWrapper>
+                        <DatepickerContentContainer
+                            ref={setContentReference}
+                            style={styles.popper}
+                            {...attributes.popper}
+                        >
+                            <Arrow ref={setArrowReference} style={styles.arrow} {...attributes.arrow} />
+                            <Datepicker
+                                numberOfMonths={1}
+                                exactMinBookingDays
+                                minBookingDays={1}
+                                startDate={value}
+                                endDate={value}
+                                minBookingDate={minDate}
+                                maxBookingDate={maxDate}
+                                firstDayOfWeek={firstDayOfWeek}
+                                focusedInput={isFocused ? START_DATE : undefined}
+                                onDatesChange={({ focusedInput, startDate }) => {
+                                    setIsFocused(focusedInput !== null);
+                                    handleDateChange(startDate || undefined);
+                                }}
+                                isDateBlocked={isDateBlocked}
+                                locale={localeObject}
+                            />
+                        </DatepickerContentContainer>
+                    </PortalWrapper>,
                     document.body
                 )}
         </>

--- a/src/components/Datepicker/DatepickerSingleInput.tsx
+++ b/src/components/Datepicker/DatepickerSingleInput.tsx
@@ -1,6 +1,6 @@
 import { FirstDayOfWeek, START_DATE } from '@datepicker-react/hooks';
 import parse from 'date-fns/parse';
-import React, { ChangeEventHandler, FC, useEffect, useMemo, useState } from 'react';
+import React, { ChangeEventHandler, FC, Fragment, useEffect, useMemo, useState } from 'react';
 import { MarginProps, WidthProps } from 'styled-system';
 import { usePopper } from 'react-popper';
 import { createPortal } from 'react-dom';
@@ -163,7 +163,7 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
     };
 
     const PortalWrapper = useMemo(() => {
-        if (!enforcedColorScheme) return React.Fragment;
+        if (!enforcedColorScheme) return Fragment;
         return enforcedColorScheme === 'light' ? LightScheme : DarkScheme;
     }, [enforcedColorScheme]);
 

--- a/src/components/Datepicker/DatepickerSingleInput.tsx
+++ b/src/components/Datepicker/DatepickerSingleInput.tsx
@@ -4,7 +4,7 @@ import React, { ChangeEventHandler, FC, useEffect, useState } from 'react';
 import { MarginProps, WidthProps } from 'styled-system';
 import { usePopper } from 'react-popper';
 import { createPortal } from 'react-dom';
-import { Input } from '../Input/Input';
+import { Input, InputProps } from '../Input/Input';
 
 import { Datepicker } from './Datepicker';
 import { isValidDateText } from './utils/isValidDateText';
@@ -14,15 +14,10 @@ import { dateToDisplayText } from './utils/dateToDisplayText';
 import { useLocaleObject } from './utils/useLocaleObject';
 import { Arrow, DatepickerContentContainer } from './DatepickerContentElements';
 
-interface DatepickerSingleInputProps extends MarginProps, WidthProps {
-    /**
-     * Placeholder for the input.
-     */
-    placeholder?: string;
-    /**
-     * Label for the input.
-     */
-    label?: string;
+interface DatepickerSingleInputProps
+    extends MarginProps,
+        WidthProps,
+        Omit<InputProps, 'value' | 'onChange' | 'disabled'> {
     /**
      * Function that is used when datepicker closes without selected date.
      */
@@ -85,8 +80,6 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
     isDateBlocked,
     onClose,
     onChange,
-    placeholder,
-    label,
     displayFormat = 'dd/MM/yyyy',
     locale = 'en-US',
     value,
@@ -176,8 +169,6 @@ const DatepickerSingleInput: FC<DatepickerSingleInputProps> = ({
                 autoComplete="off"
                 className="startDate"
                 data-testid="start-date-input"
-                label={label}
-                placeholder={placeholder}
                 value={inputText}
                 onFocus={() => setIsFocused(true)}
                 onBlur={handleDatepickerClose}

--- a/src/components/Datepicker/docs/DatepickerOnModal.tsx
+++ b/src/components/Datepicker/docs/DatepickerOnModal.tsx
@@ -18,7 +18,7 @@ export const DatepickerOnModal: FC = () => {
                         <>
                             <Headline as="h2">New Event</Headline>
 
-                            <DatePicker value={value} onChange={setValue} />
+                            <DatePicker label="Date" value={value} onChange={setValue} />
 
                             <br />
                             <Button onClick={dismiss}>Add Event</Button>

--- a/src/components/Input/InnerInput.tsx
+++ b/src/components/Input/InnerInput.tsx
@@ -58,9 +58,10 @@ const InnerInput = forwardRef<HTMLInputElement, InputWrapperProps & InputProps>(
 
         if (variant === 'bottom-lined') {
             return (
-                <InputWrapper ref={ref} {...classNameProps} {...marginProps} {...widthProps}>
+                <InputWrapper {...classNameProps} {...marginProps} {...widthProps}>
                     <BottomLinedInput
                         {...rest}
+                        ref={innerRef}
                         variant={variant}
                         id={id}
                         waveSize={size}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -9,6 +9,8 @@ import { getSemanticValue } from '../../utils/cssVariables';
 import { get } from '../../utils/themeGet';
 import { Text } from '../Text/Text';
 import { InvertedColorScheme } from '../ColorScheme/InvertedColorScheme';
+import { DarkScheme, LightScheme } from '../ColorScheme';
+import { useClosestColorScheme } from '../../utils/hooks/useClosestColorScheme';
 
 const fadeAnimation = keyframes`
     from {
@@ -162,6 +164,13 @@ const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = ({
         ]
     });
 
+    const enforcedColorScheme = useClosestColorScheme(triggerReference);
+
+    const PortalWrapper = React.useMemo(() => {
+        if (!enforcedColorScheme) return React.Fragment;
+        return enforcedColorScheme === 'light' ? LightScheme : DarkScheme;
+    }, [enforcedColorScheme]);
+
     let dynamicContent = content;
 
     if (typeof content === 'string') {
@@ -190,14 +199,16 @@ const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = ({
             {content &&
                 isVisible &&
                 createPortal(
-                    <TooltipBody
-                        ref={setContentReference}
-                        style={{ ...styles.popper }}
-                        variant={attributes.popper?.['data-popper-placement']}
-                        {...attributes.popper}
-                    >
-                        {dynamicContent}
-                    </TooltipBody>,
+                    <PortalWrapper>
+                        <TooltipBody
+                            ref={setContentReference}
+                            style={{ ...styles.popper }}
+                            variant={attributes.popper?.['data-popper-placement']}
+                            {...attributes.popper}
+                        >
+                            {dynamicContent}
+                        </TooltipBody>
+                    </PortalWrapper>,
                     document.body
                 )}
         </>

--- a/src/utils/hooks/useClosestColorScheme.ts
+++ b/src/utils/hooks/useClosestColorScheme.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+
+/**
+ * useClosestColorScheme - Returns 'light' / 'dark' based on the enforced color scheme closest to the element passed or `undefined` when no color scheme is enforced
+ */
+export const useClosestColorScheme = (element?: HTMLElement): 'light' | 'dark' | undefined =>
+    useMemo(() => {
+        if (!element) return undefined;
+
+        const closestParentWithColorScheme = element.closest('.wave');
+        if (!closestParentWithColorScheme) return undefined;
+
+        const hasEnforcedLightScheme = closestParentWithColorScheme.classList.contains('light-scheme');
+        if (hasEnforcedLightScheme) return 'light';
+
+        const hasEnforcedDarkScheme = closestParentWithColorScheme.classList.contains('dark-scheme');
+        if (hasEnforcedDarkScheme) return 'dark';
+
+        return undefined;
+    }, [element]);

--- a/src/utils/hooks/useClosestColorScheme.ts
+++ b/src/utils/hooks/useClosestColorScheme.ts
@@ -1,20 +1,44 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useMutationObserver } from './useMutationObserver';
+
+type ColorScheme = 'light' | 'dark' | undefined;
+
+const getColorSchemeFromElement = (element?: Element): ColorScheme => {
+    if (!element) return undefined;
+
+    const hasEnforcedLightScheme = element.classList.contains('light-scheme');
+    if (hasEnforcedLightScheme) return 'light';
+
+    const hasEnforcedDarkScheme = element.classList.contains('dark-scheme');
+    if (hasEnforcedDarkScheme) return 'dark';
+
+    return undefined;
+};
 
 /**
- * useClosestColorScheme - Returns 'light' / 'dark' based on the enforced color scheme closest to the element passed or `undefined` when no color scheme is enforced
+ * Gets the enforced color scheme closest to the @param element
+ *
+ * @param element DOM element
+ * @returns 'light' / 'dark' or `undefined` when no color scheme is enforced
  */
-export const useClosestColorScheme = (element?: HTMLElement): 'light' | 'dark' | undefined =>
-    useMemo(() => {
-        if (!element) return undefined;
+export const useClosestColorScheme = (element?: Element): ColorScheme => {
+    const closestParentWithColorScheme = useMemo(() => element?.closest('.wave'), [element]);
 
-        const closestParentWithColorScheme = element.closest('.wave');
-        if (!closestParentWithColorScheme) return undefined;
+    const [closestColorScheme, setClosestColorScheme] = useState<ColorScheme>();
 
-        const hasEnforcedLightScheme = closestParentWithColorScheme.classList.contains('light-scheme');
-        if (hasEnforcedLightScheme) return 'light';
+    useEffect(() => {
+        const colorScheme = getColorSchemeFromElement(closestParentWithColorScheme);
+        setClosestColorScheme(colorScheme);
+    }, [closestParentWithColorScheme]);
 
-        const hasEnforcedDarkScheme = closestParentWithColorScheme.classList.contains('dark-scheme');
-        if (hasEnforcedDarkScheme) return 'dark';
+    const callback = mutations => {
+        const lastMutation: MutationRecord = mutations[mutations.length - 1];
+        const changedElement = lastMutation.target as Element;
 
-        return undefined;
-    }, [element]);
+        setClosestColorScheme(getColorSchemeFromElement(changedElement));
+    };
+
+    useMutationObserver(closestParentWithColorScheme, callback, { attributes: true, attributeFilter: ['class'] });
+
+    return closestColorScheme;
+};

--- a/src/utils/hooks/useMutationObserver.ts
+++ b/src/utils/hooks/useMutationObserver.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Watch for mutations in the DOM through the MutationObserver API
+ *
+ * @param element - DOM element or undefined
+ * @param callback - callback to execute on mutations
+ * @param options - Options passed to mutation observer
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+ */
+export function useMutationObserver(
+    element: Element | undefined,
+    callback: MutationCallback,
+    options: MutationObserverInit = {}
+): void {
+    const observer = useRef<MutationObserver | null>(null);
+
+    const stop = useCallback(() => {
+        if (!observer.current) return;
+
+        observer.current.disconnect();
+        // eslint-disable-next-line unicorn/no-null
+        observer.current = null;
+    }, []);
+
+    useEffect(() => {
+        if (!element) return;
+
+        observer.current = new MutationObserver(callback);
+        observer.current?.observe(element, options);
+
+        // eslint-disable-next-line consistent-return
+        return stop;
+    }, [callback, stop, options, element]);
+
+    useEffect(() => stop, []);
+}


### PR DESCRIPTION
## What

Fixes a bug where enforced color schemes would not get applied to components in Portals (Datepickers and Tooltip)

### Media

Light scheme is enforced to Datepicker but only gets applied to the trigger input, the actual Datepicker is still dark
<img width="394" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/eb411432-68d5-494e-9652-1f9fc07b9f45">

Corrected behaviour
 
<img width="395" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/9b6db1e3-666e-43f4-bb3a-230355890660">


## Why

If a user wants to enforce a color scheme to a component it should get applied to the whole component, not just part of it


## How

- Create a utility hook `useClosestColorScheme` that finds the enforced color scheme closest to the passed element
- Wrap portal content in `LigthScheme`/`DarkScheme`/`React.Fragment` based on the result of `useClosestColorScheme` passing the trigger element (e.g. the input that renders the Datepicker when you click on it), this is done for both Datepickers as well as Tooltip (all components that use portals)

Closes #426 