### PR TITLE
fix(offcanvas): export offcanvas hook

### DIFF
--- a/src/components/Modal/docs/Modal.stories.tsx
+++ b/src/components/Modal/docs/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { StoryObj, Meta } from '@storybook/react';
-import { Modal, useModalDismiss } from '../Modal';
+import { Modal } from '../Modal';
 import { Button } from '../../Button/Button';
 
 const meta: Meta = {
@@ -58,21 +58,4 @@ export const WithoutAutomaticDismiss: Story = {
     args: {
         dismissible: false
     }
-};
-
-export const DismissedWithRenderProps: Story = {
-    render: args => <Modal {...args}>{dismiss => <Button onClick={dismiss}>Close</Button>}</Modal>
-};
-
-const Content = () => {
-    const dismiss = useModalDismiss();
-    return <Button onClick={dismiss}>Close</Button>;
-};
-
-export const DismissedWithHook: Story = {
-    render: args => (
-        <Modal {...args}>
-            <Content />
-        </Modal>
-    )
 };

--- a/src/components/Offcanvas/Offcanvas.tsx
+++ b/src/components/Offcanvas/Offcanvas.tsx
@@ -60,7 +60,7 @@ const ANIMATION_DURATION = Math.max(
 const Offcanvas: React.FC<OffcanvasProps> = ({
     children,
     onClose,
-    dismissible,
+    dismissible = true,
     side = 'left',
     ...rest
 }: OffcanvasProps) => {
@@ -110,10 +110,6 @@ const Offcanvas: React.FC<OffcanvasProps> = ({
             <PreventBackgroundScroll />
         </DismissContext.Provider>
     );
-};
-
-Offcanvas.defaultProps = {
-    dismissible: true
 };
 
 export { Offcanvas, OffcanvasProps, useOffcanvasDismiss };

--- a/src/components/Offcanvas/docs/Offcanvas.stories.tsx
+++ b/src/components/Offcanvas/docs/Offcanvas.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react';
-import { Offcanvas, useOffcanvasDismiss } from '../Offcanvas';
+import { Offcanvas } from '../Offcanvas';
 import { Button } from '../../Button/Button';
 
 const meta: Meta = {
@@ -56,21 +56,4 @@ export const FromRightSide: Story = {
     args: {
         side: 'right'
     }
-};
-
-export const DismissedWithRenderProps: Story = {
-    render: args => <Offcanvas {...args}>{dismiss => <Button onClick={dismiss}>Close</Button>}</Offcanvas>
-};
-
-const Content = () => {
-    const dismiss = useOffcanvasDismiss();
-    return <Button onClick={dismiss}>Close</Button>;
-};
-
-export const DismissedWithHook: Story = {
-    render: args => (
-        <Offcanvas {...args}>
-            <Content />
-        </Offcanvas>
-    )
 };

--- a/src/components/Offcanvas/docs/Offcanvas.storybook.mdx
+++ b/src/components/Offcanvas/docs/Offcanvas.storybook.mdx
@@ -11,7 +11,7 @@ its complexity level has to be simple. Consider the fullscreen state if you want
 content.
 
 Offcanvas is responsive per default but the width can be adjusted (the default is 600px or 37.5rem). Content on the Offcanvas
-is scrollable and has a space5 bounding box.
+is scrollable and has a space 5 bounding box.
 
 <Primary />
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -51,7 +51,7 @@ export { Search, SearchProps } from './Search/Search';
 export { Password } from './Password/Password';
 export { VisuallyHidden } from './VisuallyHidden/VisuallyHidden';
 export { RadioButtonProps } from './RadioButton/RadioButtonProps';
-export { Offcanvas, OffcanvasProps } from './Offcanvas/Offcanvas';
+export { Offcanvas, OffcanvasProps, useOffcanvasDismiss } from './Offcanvas/Offcanvas';
 export { SelectListProps } from './SelectList/types';
 export { Row, RowProps, Column, ColumnProps } from './Grid/Grid';
 export { Popover, PopoverProps } from './Popover/Popover';


### PR DESCRIPTION
## What

Fixes an issue where the `useOffcanvasDismiss` hook was not being exported. Fixes issues with scrolling in the docs

### Media

Check out in our docs how scrolling is not possible for the [Offcanvas](https://wave.free-now.com/?path=/docs/components-offcanvas--docs) and [Modal](http://localhost:6006/?path=/docs/components-modal--docs) docs
​
Modal scrolling now

https://github.com/freenowtech/wave/assets/46452321/03475132-00e9-45df-baaa-ea0eb79e87d3

Offcanvas scrolling now

https://github.com/freenowtech/wave/assets/46452321/00e4e291-bbea-41d3-b03f-30b43f59b2fd


## Why

We need to export `useOffcanvasDismiss` to be able to dismiss the `Offcanvas` through a hook
We should be able to scroll in our docs site 😅 
​
## How

- Export `useOffcanvasDismiss` in the components index
- Removed `defaultProps` in `Offcanvas` in favour of default arguments in the component
- Remove `Modal` and `Offcanvas` stories that use a `render` other than the default, having multiple stories using `render` causes this weird issue where scrolling stops working

### Extra ❗ 

In my opinion we can safely remove those stories since all of them were to demo the render props vs hook dismiss options and they are already explained in a section on top of the stories for both Modal and Offcanvas, if you think it's worth keeping them I can open a separate issue for that and keep this PR for only exporting the hook and refactoring the default props
