### PR TITLE
docs: document recommendation to get rid of prop filtering warnings

### DIFF
--- a/docs/get-started.storybook.mdx
+++ b/docs/get-started.storybook.mdx
@@ -78,4 +78,5 @@ const Root = () => (
 );
 ```
 
+For the actual filtering function we recommend using the [@emotion/is-prop-valid](https://www.npmjs.com/package/@emotion/is-prop-valid) package to have a plug-and-play solution.
 For more information check out [this section in the styled-components docs about the change](https://styled-components.com/docs/faqs#shouldforwardprop-is-no-longer-provided-by-default).

--- a/docs/get-started.storybook.mdx
+++ b/docs/get-started.storybook.mdx
@@ -47,3 +47,35 @@ You'll see this:
     <Headline>Welcome</Headline>
     <Text>FREE NOW Design System</Text>
 </Card>
+
+## Considerations
+
+<br />
+
+### Usage with styled-components v6
+
+Wave will work with versions of `styled-components` higher than `4.3`, but in case you are using version `6` or above you may see warnings similar to `Warning: React does not recognize the {x} prop on a DOM element...`.
+The warnings appear because starting from v6 [`styled-components` does NOT automatically filter props anymore](https://styled-components.com/releases#v6.0.0), which results in props that are meant only for React components reaching the actual DOM.
+To get rid of these warning you can wrap your app with `StyleSheetManager` and pass a `shouldForwardProp` function like:
+
+```tsx
+import isPropValid from '@emotion/is-prop-valid';
+import { StyleSheetManager } from 'styled-components';
+
+const shouldForwardProp = (propName, target) => {
+    if (typeof target === 'string') {
+        // For HTML elements, forward the prop if it is a valid HTML attribute
+        return isPropValid(propName);
+    }
+    // For other elements, forward all props
+    return true;
+};
+
+const Root = () => (
+    <StyleSheetManager shouldForwardProp={shouldForwardProp}>
+        <App />
+    </StyleSheetManager>
+);
+```
+
+For more information check out [this section in the styled-components docs about the change](https://styled-components.com/docs/faqs#shouldforwardprop-is-no-longer-provided-by-default).


### PR DESCRIPTION
## What

Document how to get rid of prop filtering warnings in the `Get started` section

### Media

<img width="1081" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/fbce2ea3-2194-47e1-8505-5beb7f2f7185">
​

## Why

So users of Wave can easily understand how to avoid undesired props being filtered to the DOM and React emitting warnings about it

## How

- Add an explanation of how to use `StyleSheetManager` in the get started section

Relates to #388
