### PR TITLE
fix(SelectList): overwrite styling with enforced color scheme for menu

### DIFF
--- a/src/components/ColorScheme/EnforcedColorScheme.tsx
+++ b/src/components/ColorScheme/EnforcedColorScheme.tsx
@@ -7,7 +7,11 @@ export interface EnforcedColorSchemeProps extends BoxProps {
 }
 
 export const EnforcedColorScheme: React.FC<EnforcedColorSchemeProps> = ({ scheme, children, ...props }) => (
-    <Box {...props} className={`${scheme === 'dark' ? 'dark-scheme' : 'light-scheme'} wave`}>
+    <Box
+        {...props}
+        className={`${scheme === 'dark' ? 'dark-scheme' : 'light-scheme'} wave`}
+        style={{ background: 'inherit' }}
+    >
         {children}
     </Box>
 );

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import {
     ClearIndicatorProps,
     components as ReactSelectComponents,
@@ -21,6 +21,7 @@ import { Label } from './components/Label';
 import { Wrapper } from './components/Wrapper';
 import { disabledStyles, errorStyles, variantStyles } from './styles';
 import { SelectListProps } from './types';
+import { MenuProps } from 'react-select';
 
 type WithSelectProps<T> = T & { selectProps: SelectListProps };
 
@@ -314,6 +315,7 @@ const MultiValueRemove = props => (
 // eslint-disable-next-line react/prop-types
 const LightSchemeMenu = ({ children, ...props }) => (
     <LightScheme>
+        {/* @ts-expect-error ts(2740) */}
         <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
     </LightScheme>
 );
@@ -321,12 +323,14 @@ const LightSchemeMenu = ({ children, ...props }) => (
 // eslint-disable-next-line react/prop-types
 const DarkSchemeMenu = ({ children, ...props }) => (
     <DarkScheme>
+        {/* @ts-expect-error ts(2740) */}
         <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
     </DarkScheme>
 );
 
 // eslint-disable-next-line react/prop-types
 const DefaultMenu = ({ children, ...props }) => (
+    // @ts-expect-error ts(2740)
     <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
 );
 

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -312,20 +312,20 @@ const MultiValueRemove = props => (
     </ReactSelectComponents.MultiValueRemove>
 );
 
-const LightSchemeMenu = (children, props: WithSelectProps<MenuProps>) => (
+const LightSchemeMenu = (props: WithSelectProps<MenuProps>) => (
     <LightScheme>
-        <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
+        <ReactSelectComponents.Menu {...props}>{props.children}</ReactSelectComponents.Menu>
     </LightScheme>
 );
 
-const DarkSchemeMenu = (children, props: WithSelectProps<MenuProps>) => (
+const DarkSchemeMenu = (props: WithSelectProps<MenuProps>) => (
     <DarkScheme>
-        <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
+        <ReactSelectComponents.Menu {...props}>{props.children}</ReactSelectComponents.Menu>
     </DarkScheme>
 );
 
-const DefaultMenu = (children, props: WithSelectProps<MenuProps>) => (
-    <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
+const DefaultMenu = (props: WithSelectProps<MenuProps>) => (
+    <ReactSelectComponents.Menu {...props}>{props.children}</ReactSelectComponents.Menu>
 );
 
 const SelectList: FC<SelectListProps> = (props: SelectListProps) => {

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -3,6 +3,7 @@ import {
     ClearIndicatorProps,
     components as ReactSelectComponents,
     ControlProps,
+    MenuProps,
     DropdownIndicatorProps,
     Props,
     StylesConfig
@@ -311,25 +312,19 @@ const MultiValueRemove = props => (
     </ReactSelectComponents.MultiValueRemove>
 );
 
-// eslint-disable-next-line react/prop-types
-const LightSchemeMenu = ({ children, ...props }) => (
+const LightSchemeMenu = (children, props: WithSelectProps<MenuProps>) => (
     <LightScheme>
-        {/* @ts-expect-error ts(2740) */}
         <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
     </LightScheme>
 );
 
-// eslint-disable-next-line react/prop-types
-const DarkSchemeMenu = ({ children, ...props }) => (
+const DarkSchemeMenu = (children, props: WithSelectProps<MenuProps>) => (
     <DarkScheme>
-        {/* @ts-expect-error ts(2740) */}
         <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
     </DarkScheme>
 );
 
-// eslint-disable-next-line react/prop-types
-const DefaultMenu = ({ children, ...props }) => (
-    // @ts-expect-error ts(2740)
+const DefaultMenu = (children, props: WithSelectProps<MenuProps>) => (
     <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
 );
 

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -15,6 +15,8 @@ import { extractClassNameProps, extractWidthProps, extractWrapperMarginProps } f
 import { getSemanticValue } from '../../utils/cssVariables';
 import { useGeneratedId } from '../../utils/hooks/useGeneratedId';
 import { get } from '../../utils/themeGet';
+import { useClosestColorScheme } from '../../utils/hooks/useClosestColorScheme';
+import { DarkScheme, LightScheme } from '../ColorScheme';
 import { Label } from './components/Label';
 import { Wrapper } from './components/Wrapper';
 import { disabledStyles, errorStyles, variantStyles } from './styles';
@@ -309,21 +311,51 @@ const MultiValueRemove = props => (
     </ReactSelectComponents.MultiValueRemove>
 );
 
+// eslint-disable-next-line react/prop-types
+const LightSchemeMenu = ({ children, ...props }) => (
+    <LightScheme>
+        <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
+    </LightScheme>
+);
+
+// eslint-disable-next-line react/prop-types
+const DarkSchemeMenu = ({ children, ...props }) => (
+    <DarkScheme>
+        <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
+    </DarkScheme>
+);
+
+// eslint-disable-next-line react/prop-types
+const DefaultMenu = ({ children, ...props }) => (
+    <ReactSelectComponents.Menu {...props}>{children}</ReactSelectComponents.Menu>
+);
+
 const SelectList: FC<SelectListProps> = (props: SelectListProps) => {
     const { classNameProps, restProps: withoutClassName } = extractClassNameProps(props);
     const { marginProps, restProps: withoutMargin } = extractWrapperMarginProps(withoutClassName);
     const { widthProps, restProps } = extractWidthProps(withoutMargin);
     const { components, isDisabled, variant, size, error, label, inputId } = restProps;
+    const [triggerReference, setTriggerReference] = React.useState(undefined);
 
     const id = useGeneratedId(inputId);
 
+    const enforcedColorScheme = useClosestColorScheme(triggerReference);
+
+    const Menu =
+        enforcedColorScheme === 'light'
+            ? LightSchemeMenu
+            : enforcedColorScheme === 'dark'
+            ? DarkSchemeMenu
+            : DefaultMenu;
+
     return (
-        <Wrapper {...classNameProps} {...marginProps} {...widthProps}>
+        <Wrapper ref={setTriggerReference} {...classNameProps} {...marginProps} {...widthProps}>
             <WindowedSelect
                 inputId={id}
                 styles={customStyles}
                 windowThreshold={100}
                 components={{
+                    Menu,
                     DropdownIndicator,
                     IndicatorSeparator,
                     ClearIndicator,

--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC } from 'react';
 import {
     ClearIndicatorProps,
     components as ReactSelectComponents,
@@ -21,7 +21,6 @@ import { Label } from './components/Label';
 import { Wrapper } from './components/Wrapper';
 import { disabledStyles, errorStyles, variantStyles } from './styles';
 import { SelectListProps } from './types';
-import { MenuProps } from 'react-select';
 
 type WithSelectProps<T> = T & { selectProps: SelectListProps };
 


### PR DESCRIPTION
## What

Fixing the problem from Issue #434 

### Media

https://www.loom.com/share/a76665438d7745adb3abeb1cf962e7b6?sid=73419f0a-b715-4d97-afa9-e3fc575b82d3




## How

- Use `useClosestColorScheme` to identify if enforced color scheme is applied
- Wrap the `Menu` component from `react-windowed-select` with respective color scheme component