### PR TITLE
fix: extends InputProps on search and spread into search SyledInput

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -8,7 +8,7 @@ import { XCrossIcon, MagnifierIcon } from '../../icons';
 import { useControlledState } from '../../utils/hooks/useControlledState';
 import { Box, BoxProps } from '../Box/Box';
 
-import { Input } from '../Input/Input';
+import { Input, type InputProps } from '../Input/Input';
 
 const ActiveStyle = `
     background-color: ${getSemanticValue('background-element-info-default')};
@@ -75,7 +75,7 @@ const StyledInput = styled(Input)`
     }
 `;
 
-export interface SearchProps {
+export interface SearchProps extends Omit<InputProps, 'results'> {
     results?: React.ReactNode[];
     /**
      * Sets the value
@@ -97,18 +97,6 @@ export interface SearchProps {
      * Sets the width of the search box
      */
     width?: string;
-    /**
-     * Sets the placeholder text to be shown
-     */
-    placeholder?: string;
-    /**
-     * Determines whether the search box is disabled
-     */
-    disabled?: boolean;
-    /**
-     * Determines the size of the search box
-     */
-    size?: 'small' | 'medium';
     /**
      * This function is called when the "Enter" key is pressed or the search icon is clicked
      */
@@ -142,7 +130,8 @@ export const Search: FC<SearchProps> = ({
     onInputChange,
     onClear,
     onEnter,
-    onChangeSelection
+    onChangeSelection,
+    ...props
 }: SearchProps) => {
     const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -270,6 +259,7 @@ export const Search: FC<SearchProps> = ({
                     onChange={handleChangeValue}
                     onFocus={() => setIsInFocus(true)}
                     onBlur={() => setIsInFocus(false)}
+                    {...props}
                 />
 
                 {!value ? undefined : (


### PR DESCRIPTION
## What

Make `SearchProps` extend the `InputProps` and spread its props into the `StyledInput` of the `Search` component.

### Media

No UI change.

## Why

Search missed a few `InputProps` to it's `StyledInput`; the one missing that we currently wanted to use is `autoFocus` so that we can have the user automatically focus in the SearchInput with a single attribute.

## How

Making `SearchProps extend InputProps` (omitting results because of conflict) and removing a few props from `SearchProps` (disabled, placeholder, size) as they are already in `InputProps`
