### PR TITLE
fix(tabbar): make Wave's theme apply to TabBar component

### DIFF
--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { margin } from 'styled-system';
 
+import { theme } from '../../essentials/theme';
 import { Link } from './Link';
 import { TabBarWithLink } from './TabBarWithLink';
 
 const TabBar: TabBarWithLink = Object.assign(
-    styled.nav`
+    styled.nav.attrs({ theme })`
         display: flex;
 
         ${margin}


### PR DESCRIPTION
## What

Make Wave's theme apply to `TabBar` component

### Media

```tsx
{/* When passing a margin to TabBar it doesn't apply it correctly */}
{/* mb={3} should equal 24px (Spaces[3]), it is 16px instead */}
<TabBar mb={3}>
  {['Tab One', 'Tab Two'].map(it => (
    <TabBar.Link
        key={it}
        href="#"
        onClick={e => {
            e.preventDefault();
            setSelected(it);
        }}
        selected={selected === it}
    >
        {it}
    </TabBar.Link>
  ))}
</TabBar>
{/* Here's a correct margin for comparison */}
<Box width='100%' mb={3} >The margin above is 16px, but should be 24px</Box>
<Box width='100%' >The margin above is 24px</Box>
```

<img width="575" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/9b907409-f25c-43cb-b430-54253a3724ca">


Check it out in this [CodeSandbox](https://codesandbox.io/p/sandbox/wave-tabbar-margin-bug-tgl46v?file=%2Fsrc%2FApp.tsx%3A30%2C16)

## Why

All Wave components should have Wave's theme applied to them

​
## How

- Pass our `theme` as a styled component attribute in `TabBar`
