### PR TITLE
fix: remove width from pageSize selectList box

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -12,8 +12,8 @@ const Container = styled.div`
 
 const ButtonsContainer = styled(Box)`
     display: flex;
-    justify-content: center;
-    position: relative;
+    align-items: center;
+    gap: ${Spaces[1]};
 `;
 
 const IconButton = styled.button`
@@ -140,34 +140,39 @@ const Pagination: React.FC<PaginationProps> = ({
     return (
         <Container>
             <ButtonsContainer>
-                {hasMultiplePageSizes && (
-                    <Box aria-label={ariaLabelSelectPageSizeContainer} position="absolute" left="0">
-                        <SelectList
-                            options={pageSizes}
-                            onChange={onSelectPageSize}
-                            value={pageSizes.find(sizeOption => sizeOption.value === pageSize.toString())}
-                        />
-                    </Box>
-                )}
-                {size !== 'small' && (
-                    <IconButton aria-label={ariaLabelFirst} disabled={isFirstPage} onClick={onSkipBackward}>
-                        <BackwardLastIcon size="small" color="inherit" />
+                <Box flex="1">
+                    {hasMultiplePageSizes && (
+                        <Box aria-label={ariaLabelSelectPageSizeContainer} minWidth="5em" maxWidth="5.5em">
+                            <SelectList
+                                options={pageSizes}
+                                onChange={onSelectPageSize}
+                                value={pageSizes.find(sizeOption => sizeOption.value === pageSize.toString())}
+                            />
+                        </Box>
+                    )}
+                </Box>
+                <Box>
+                    {size !== 'small' && (
+                        <IconButton aria-label={ariaLabelFirst} disabled={isFirstPage} onClick={onSkipBackward}>
+                            <BackwardLastIcon size="small" color="inherit" />
+                        </IconButton>
+                    )}
+
+                    <IconButton aria-label={ariaLabelPrevious} disabled={isFirstPage} onClick={onPrevPage}>
+                        <BackwardIcon size="small" color="inherit" />
                     </IconButton>
-                )}
 
-                <IconButton aria-label={ariaLabelPrevious} disabled={isFirstPage} onClick={onPrevPage}>
-                    <BackwardIcon size="small" color="inherit" />
-                </IconButton>
-
-                <IconButton aria-label={ariaLabelNext} disabled={isLastPage} onClick={onNextPage}>
-                    <ForwardIcon size="small" color="inherit" />
-                </IconButton>
-
-                {size !== 'small' && (
-                    <IconButton aria-label={ariaLabelLast} disabled={isLastPage} onClick={onSkipForward}>
-                        <ForwardLastIcon size="small" color="inherit" />
+                    <IconButton aria-label={ariaLabelNext} disabled={isLastPage} onClick={onNextPage}>
+                        <ForwardIcon size="small" color="inherit" />
                     </IconButton>
-                )}
+
+                    {size !== 'small' && (
+                        <IconButton aria-label={ariaLabelLast} disabled={isLastPage} onClick={onSkipForward}>
+                            <ForwardLastIcon size="small" color="inherit" />
+                        </IconButton>
+                    )}
+                </Box>
+                <Box flex="1" />
             </ButtonsContainer>
 
             {label && <LabelContainer>{label}</LabelContainer>}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -141,7 +141,7 @@ const Pagination: React.FC<PaginationProps> = ({
         <Container>
             <ButtonsContainer>
                 {hasMultiplePageSizes && (
-                    <Box aria-label={ariaLabelSelectPageSizeContainer} position="absolute" left="0" width="4.5em">
+                    <Box aria-label={ariaLabelSelectPageSizeContainer} position="absolute" left="0">
                         <SelectList
                             options={pageSizes}
                             onChange={onSelectPageSize}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -142,7 +142,7 @@ const Pagination: React.FC<PaginationProps> = ({
             <ButtonsContainer>
                 <Box flex="1">
                     {hasMultiplePageSizes && (
-                        <Box aria-label={ariaLabelSelectPageSizeContainer} minWidth="5em" maxWidth="5.5em">
+                        <Box aria-label={ariaLabelSelectPageSizeContainer} width="fit-content" minWidth="5em">
                             <SelectList
                                 options={pageSizes}
                                 onChange={onSelectPageSize}


### PR DESCRIPTION
## What

Fixes the size of the Page Size selector by removing the width attribute sent to it.

### Media

Page size selector with not broken size:
<img width="1352" alt="image" src="https://github.com/freenowtech/wave/assets/153822795/710f65cb-6c75-4ecb-8e7f-eb9c79d9cb75">

Responsiveness of boxes:

https://github.com/freenowtech/wave/assets/153822795/bbe228e3-1486-4cf0-b930-c01bd44a4d45

## Why

There is a bug where the page size selector is too small and does not fully display the number of the selected page size. By removing the set `width="4.5em"` it displays the selected page size correctly.

## How

Adds 3 boxes inside of ButtonsContainers, with the left (PageSize selector) and right (empty) having `flex='1'` so that they take the necessary space, and having the box with the pagination navigation in the middle.

Sets the container inside of the first flexable box with `minWidth='5em'` and `width="fit-content"` so that the PageSize selector can't be as small as it was before, but also the box around it keeps the having the same size as the SelectList 


Closes #331 