### PR TITLE
fix: add missing type exports

### DIFF
--- a/src/components/Datepicker/index.ts
+++ b/src/components/Datepicker/index.ts
@@ -4,5 +4,6 @@ export {
 } from './DatepickerSingleInput';
 export {
     DatepickerRangeInput as DateRangePicker,
-    DatepickerRangeInputProps as DateRangePickerProps
+    DatepickerRangeInputProps as DateRangePickerProps,
+    DateRange
 } from './DatepickerRangeInput';

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -5,3 +5,4 @@ export { TableHeaderCell, TableHeaderCellProps } from './components/TableHeaderC
 export { TableRowSkeleton, TableRowSkeletonProps } from './components/TableRowSkeleton';
 export { TableSortableHeaderCell, TableSortableHeaderCellProps } from './components/TableSortableHeaderCell';
 export { useSortBy } from './hooks/useSortBy';
+export { SortingDirection } from './types';


### PR DESCRIPTION
## What

Adds missing type exports on the `Table` and and `Datepicker` components

## Why

We were missing types in some projects and had imports like 

`​import type { DateRange } from '@freenow/wave/lib/types/components/Datepicker/DatepickerRangeInput'`

## How

- Export `DateRange` from `src/components/Datepicker/index.ts``
- Export `SortingDirection` from `src/components/Table/index.ts`