### PR TITLE
fix: add missing type exports in components index

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,7 +21,7 @@ export { HelperText, HelperTextProps } from './HelperText/HelperText';
 export { Tag, TagProps } from './Tag/Tag';
 export { InlineSpinner, InlineSpinnerProps } from './InlineSpinner/InlineSpinner';
 export { TabBar, TabBarWithLink as TabBarProps } from './TabBar/TabBar';
-export { DatePicker, DateRangePicker, DateRangePickerProps, DatePickerProps } from './Datepicker';
+export { DatePicker, DateRangePicker, DateRangePickerProps, DatePickerProps, DateRange } from './Datepicker';
 export { Divider, DividerProps } from './Divider/Divider';
 export { Tooltip, TooltipProps } from './Tooltip/Tooltip';
 export { Toggle, ToggleProps } from './Toggle/Toggle';
@@ -40,7 +40,8 @@ export {
     TableRowSkeletonProps,
     TableSortableHeaderCell,
     TableSortableHeaderCellProps,
-    useSortBy
+    useSortBy,
+    SortingDirection
 } from './Table';
 export { FilePicker, FilePickerProps } from './FilePicker';
 export { PhoneInput, PhoneInputProps } from './PhoneInput/PhoneInput';


### PR DESCRIPTION
## What

Add missing type exports in components index files


### Media

N/A

## Why

In #445 I added missing type exports to the `Table` and `Datepicker` components index files, but I was missing those exports in the `/components/index.ts` file 🙈
​

## How

- Export `DateRange` and `SortingDirection` from ' /components/index`
