### PR TITLE
feat: add semantic colors for chart (#448)

### DIFF
--- a/src/essentials/Colors/Colors.ts
+++ b/src/essentials/Colors/Colors.ts
@@ -211,6 +211,14 @@ export const SemanticColors = {
     },
     shadow: {
         default: Colors.blue.primary[200]
+    },
+    chart: {
+        '1': Colors.blue.secondary[50],
+        '2': Colors.blue.secondary[100],
+        '3': Colors.blue.secondary[150],
+        '4': Colors.blue.secondary[350],
+        '5': Colors.blue.secondary[900],
+        '6': Colors.blue.secondary[1000]
     }
 } satisfies SemanticColorsSchema;
 
@@ -368,6 +376,14 @@ export const SemanticColorsDarkSchema = {
     },
     shadow: {
         default: Colors.blue.primary[550]
+    },
+    chart: {
+        '1': Colors.blue.secondary[50],
+        '2': Colors.blue.secondary[100],
+        '3': Colors.blue.secondary[150],
+        '4': Colors.blue.secondary[350],
+        '5': Colors.blue.secondary[900],
+        '6': Colors.blue.secondary[1000]
     }
 } satisfies SemanticColorsSchema;
 

--- a/src/essentials/Colors/ModernColors.ts
+++ b/src/essentials/Colors/ModernColors.ts
@@ -15,12 +15,17 @@ export const Colors = {
         50: 'hsl(0, 2%, 91%)'
     },
     primary: {
-        1000: 'hsl(346, 51%, 33%)',
+        1100: 'hsl(341, 100%, 13%)',
+        1000: 'hsl(343, 70%, 22%)',
+        950: 'hsl(346, 51%, 33%)',
         900: 'hsl(347, 42%, 43%)',
-        350: 'hsl(349, 89%, 76%)',
-        150: 'hsl(351, 100%, 85%)',
-        100: 'hsl(352, 100%, 93%)',
-        50: 'hsl(9, 100%, 96%)'
+        500: 'hsl(347, 41%, 50%)',
+        350: 'hsl(349, 50%, 65%)',
+        150: 'hsl(348, 50%, 76%)',
+        120: 'hsl(351, 51%, 85%)',
+        100: 'hsl(352, 48%, 91%)',
+        50: 'hsl(350, 46%, 95%)',
+        10: 'hsl(0, 47%, 97%)'
     },
     brand: {
         rushhour: 'hsl(350, 91%, 41%)'
@@ -205,6 +210,14 @@ export const SemanticColors = {
     },
     shadow: {
         default: Colors.neutral[200]
+    },
+    chart: {
+        '1': Colors.primary[50],
+        '2': Colors.primary[120],
+        '3': Colors.primary[350],
+        '4': Colors.primary[500],
+        '5': Colors.primary[950],
+        '6': Colors.primary[1100],
     }
 } satisfies SemanticColorsSchema;
 
@@ -362,6 +375,14 @@ export const SemanticColorsDarkSchema = {
     },
     shadow: {
         default: Colors.neutral[650]
+    },
+    chart: {
+        '1': Colors.primary[50],
+        '2': Colors.primary[120],
+        '3': Colors.primary[150],
+        '4': Colors.primary[350],
+        '5': Colors.primary[500],
+        '6': Colors.primary[950],
     }
 } satisfies SemanticColorsSchema;
 

--- a/src/essentials/Colors/types.ts
+++ b/src/essentials/Colors/types.ts
@@ -1,4 +1,5 @@
 import { Join, Leaves } from '../../utils/types';
+import { Colors } from './ModernColors';
 
 export type HSL = `hsl(${number}, ${number}%, ${number}%)` | `hsla(${number}, ${number}%, ${number}%, ${number})`;
 
@@ -160,6 +161,14 @@ export type SemanticColorsSchema = {
     };
     shadow: {
         default: Color;
+    };
+    chart: {
+        '1': Color;
+        '2': Color;
+        '3': Color;
+        '4': Color;
+        '5': Color;
+        '6': Color;
     };
 };
 

--- a/src/essentials/Colors/types.ts
+++ b/src/essentials/Colors/types.ts
@@ -1,5 +1,4 @@
 import { Join, Leaves } from '../../utils/types';
-import { Colors } from './ModernColors';
 
 export type HSL = `hsl(${number}, ${number}%, ${number}%)` | `hsla(${number}, ${number}%, ${number}%, ${number})`;
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

Add new semantic colors for charts.

(+ fix few existing primary colors in modern look)

### Media
Modern
<img width="1034" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/57a99f0b-41ca-48e9-ab1b-8970b7dae964">
<img width="1022" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/7abcffac-4406-4c0c-983b-8ff09ac94830">

Classic
<img width="1020" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/6e9dc467-380c-4c10-a662-0bce9ac167c3">
<img width="1021" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/50bf0b4b-858c-42bf-9942-dd8a04a6df49">


## Why
We need those colors in Admin Panel for a histogram component.

​

## How
Add new primary colors and introduce new semantic colors for `chart`.
