### PR TITLE
fix: wrong monochrome logo color

### DIFF
--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -17,7 +17,8 @@ interface LogoProps {
 }
 
 const monochromeCss = {
-    [applyPrefix('logo-free', 's')]: getSemanticValue('logo-now')
+    [applyPrefix('logo-free', 's')]: getSemanticValue('logo-subtitle'),
+    [applyPrefix('logo-now', 's')]: getSemanticValue('logo-subtitle')
 };
 
 const Logo: React.FC<LogoProps> = ({ monochrome, variant }: LogoProps) => {

--- a/src/components/Logo/docs/Logo.stories.tsx
+++ b/src/components/Logo/docs/Logo.stories.tsx
@@ -25,6 +25,13 @@ export const Business: Story = {
     }
 };
 
+export const BusinessMonochrome: Story = {
+    args: {
+        variant: 'business',
+        monochrome: true
+    }
+};
+
 export const Monochrome: Story = {
     args: {
         monochrome: true


### PR DESCRIPTION
## What

Fix wrong monochrome logo color

### Media

<img width="1063" alt="Screenshot 2024-05-27 at 11 53 46" src="https://github.com/freenowtech/wave/assets/9133431/6e8a737f-a406-4305-a6fb-b9011e8dc167">

<img width="1058" alt="Screenshot 2024-05-27 at 11 53 56" src="https://github.com/freenowtech/wave/assets/9133431/8ff7a915-968a-4c8f-8fbf-bf6afcc405f0">

## Why

The guidance from design is to use black/white for the monchrome version of the logo, specifically useful for france where we can't use the normal brand color.

## How

Replace usage of `logo-free` and `logo-now` with `logo-subtitle` if the monochrome prop is used on the Logo component.
