### PR TITLE
fix: adjust contrast ratio on selected disabled checkbox

### DIFF
--- a/src/components/Checkbox/components/Checkmark.tsx
+++ b/src/components/Checkbox/components/Checkmark.tsx
@@ -70,7 +70,7 @@ const Checkmark = styled.input<CheckmarkProps>`
 
     &:disabled {
         cursor: not-allowed;
-        background-color: ${getSemanticValue('background-element-disabled-faded')};
+        background-color: ${getSemanticValue('background-element-disabled-default')};
         box-shadow: inset 0 0 0 0.125rem ${getSemanticValue('transparent')};
 
         &:hover {
@@ -78,7 +78,7 @@ const Checkmark = styled.input<CheckmarkProps>`
         }
 
         &:active {
-            background-color: ${getSemanticValue('background-element-disabled-faded')};
+            background-color: ${getSemanticValue('background-element-disabled-default')};
         }
     }
 `;

--- a/src/components/Checkbox/docs/Checkbox.stories.tsx
+++ b/src/components/Checkbox/docs/Checkbox.stories.tsx
@@ -44,6 +44,13 @@ export const Disabled: Story = {
     }
 };
 
+export const DisabledChecked: Story = {
+    args: {
+        disabled: true,
+        defaultChecked: true
+    }
+};
+
 export const Indeterminate: Story = {
     args: {
         indeterminate: true


### PR DESCRIPTION
## What

Fix the low contrast ratio on selected disabled checkbox

### Media

<img width="950" alt="Screenshot 2024-05-31 at 13 48 50" src="https://github.com/freenowtech/wave/assets/14894844/b9752396-989c-46e4-85c0-34c87cf13ef5">


## Why

[453](https://github.com/freenowtech/wave/issues/453)

Closes #453 ​

## How

Use `background-element-disabled-default` instead of `background-element-disabled-faded`