### PR TITLE
docs: add documentation about distribution channels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,14 @@ Speak out loud for us to understand your pains is valuable, challenge current ap
 
 Feel like doing a bit more? You can check what is up for grabs in our public backlog and create a PR for it
 
+## Distribution channels
+
+We use [semantic release](https://semantic-release.gitbook.io/semantic-release) to automate our versioning and release process. Currently we have 3 distribution channels:
+
+-   `latest` tag (follows the [main](https://github.com/freenowtech/wave/tree/main) branch): It is used for releases on the current major (v2)
+-   `next` tag (follows the [next](https://github.com/freenowtech/wave/tree/next) branch): It is used for prereleases on the next major (v3)
+-   `release-1.34.x` tag (follows the [1.34.x](https://github.com/freenowtech/wave/tree/1.34.x) branch): It is used to provide maintenance on our previous major version (v1)
+
 ## Tools we use
 
 1. We use [styled-components](https://www.styled-components.com/) to style our components.


### PR DESCRIPTION
## What

Adds documentation around our distribution channels

### Media

![image](https://github.com/freenowtech/wave/assets/46452321/0bd4e20b-dbce-4f63-865a-59298c059b4f)

## Why

So contributors know in which branch to contribute depending on how they want to release the new version
