### PR TITLE
feat: add two new neutral colors and map them to new semantic color

### DIFF
--- a/src/essentials/Colors/Colors.ts
+++ b/src/essentials/Colors/Colors.ts
@@ -111,9 +111,9 @@ export const SemanticColors = {
         }
     },
     background: {
-        default: Colors.neutral[10],
         page: {
             default: Colors.white,
+            'elevation-0': Colors.blue.primary[50],
             'elevation-1': Colors.white,
             'elevation-2': Colors.white,
             'elevation-3': Colors.white
@@ -183,13 +183,6 @@ export const SemanticColors = {
             }
         },
         backdrop: Colors.blue.primary[900]
-    },
-    surface: {
-        default: Colors.white,
-        container: {
-            default: Colors.neutral[10],
-            highest: Colors.white
-        }
     },
     border: {
         accent: {
@@ -284,9 +277,9 @@ export const SemanticColorsDarkSchema = {
         }
     },
     background: {
-        default: Colors.neutral[900],
         page: {
-            default: Colors.blue.primary[900],
+            default: Colors.blue.primary[1000],
+            'elevation-0': Colors.blue.primary[1100],
             'elevation-1': Colors.blue.primary[750],
             'elevation-2': Colors.blue.primary[550],
             'elevation-3': Colors.blue.primary[350]
@@ -356,13 +349,6 @@ export const SemanticColorsDarkSchema = {
             }
         },
         backdrop: Colors.blue.primary[50]
-    },
-    surface: {
-        default: Colors.neutral[800],
-        container: {
-            default: Colors.neutral[750],
-            highest: Colors.neutral[650]
-        }
     },
     border: {
         accent: {

--- a/src/essentials/Colors/Colors.ts
+++ b/src/essentials/Colors/Colors.ts
@@ -5,6 +5,17 @@ import { createThemeGlobalStyle } from './globalStyles';
 export const Colors = {
     white: 'hsl(0, 0%, 100%)',
     black: 'hsl(0, 0%, 0%)',
+    neutral: {
+        900: 'hsl(350, 11%, 11%)',
+        800: 'hsl(0, 11%, 16%)',
+        750: 'hsl(0, 6%, 20%)',
+        650: 'hsl(353, 5%, 29%)',
+        550: 'hsl(0, 2%, 38%)',
+        350: 'hsl(0, 1%, 55%)',
+        200: 'hsl(0, 1%, 73%)',
+        50: 'hsl(0, 2%, 91%)',
+        10: 'hsl(0, 2%, 96%)'
+    },
     blue: {
         primary: {
             1100: 'hsl(211, 100%, 6%)',
@@ -100,6 +111,7 @@ export const SemanticColors = {
         }
     },
     background: {
+        default: Colors.neutral[10],
         page: {
             default: Colors.white,
             'elevation-1': Colors.white,
@@ -171,6 +183,13 @@ export const SemanticColors = {
             }
         },
         backdrop: Colors.blue.primary[900]
+    },
+    surface: {
+        default: Colors.white,
+        container: {
+            default: Colors.neutral[10],
+            highest: Colors.white
+        }
     },
     border: {
         accent: {
@@ -265,6 +284,7 @@ export const SemanticColorsDarkSchema = {
         }
     },
     background: {
+        default: Colors.neutral[900],
         page: {
             default: Colors.blue.primary[900],
             'elevation-1': Colors.blue.primary[750],
@@ -336,6 +356,13 @@ export const SemanticColorsDarkSchema = {
             }
         },
         backdrop: Colors.blue.primary[50]
+    },
+    surface: {
+        default: Colors.neutral[800],
+        container: {
+            default: Colors.neutral[750],
+            highest: Colors.neutral[650]
+        }
     },
     border: {
         accent: {

--- a/src/essentials/Colors/Colors.ts
+++ b/src/essentials/Colors/Colors.ts
@@ -5,17 +5,6 @@ import { createThemeGlobalStyle } from './globalStyles';
 export const Colors = {
     white: 'hsl(0, 0%, 100%)',
     black: 'hsl(0, 0%, 0%)',
-    neutral: {
-        900: 'hsl(350, 11%, 11%)',
-        800: 'hsl(0, 11%, 16%)',
-        750: 'hsl(0, 6%, 20%)',
-        650: 'hsl(353, 5%, 29%)',
-        550: 'hsl(0, 2%, 38%)',
-        350: 'hsl(0, 1%, 55%)',
-        200: 'hsl(0, 1%, 73%)',
-        50: 'hsl(0, 2%, 91%)',
-        10: 'hsl(0, 2%, 96%)'
-    },
     blue: {
         primary: {
             1100: 'hsl(211, 100%, 6%)',

--- a/src/essentials/Colors/ModernColors.ts
+++ b/src/essentials/Colors/ModernColors.ts
@@ -101,6 +101,7 @@ export const SemanticColors = {
         }
     },
     background: {
+        default: Colors.neutral[10],
         page: {
             default: Colors.white,
             'elevation-1': Colors.white,
@@ -172,6 +173,13 @@ export const SemanticColors = {
             }
         },
         backdrop: Colors.neutral[900]
+    },
+    surface: {
+        default: Colors.white,
+        container: {
+            default: Colors.neutral[10],
+            highest: Colors.white
+        }
     },
     border: {
         accent: {
@@ -266,6 +274,7 @@ export const SemanticColorsDarkSchema = {
         }
     },
     background: {
+        default: Colors.neutral[900],
         page: {
             default: Colors.neutral[900],
             'elevation-1': Colors.neutral[750],
@@ -337,6 +346,13 @@ export const SemanticColorsDarkSchema = {
             }
         },
         backdrop: Colors.neutral[50]
+    },
+    surface: {
+        default: Colors.neutral[800],
+        container: {
+            default: Colors.neutral[750],
+            highest: Colors.neutral[650]
+        }
     },
     border: {
         accent: {

--- a/src/essentials/Colors/ModernColors.ts
+++ b/src/essentials/Colors/ModernColors.ts
@@ -6,13 +6,15 @@ export const Colors = {
     white: 'hsl(0, 0%, 99%)',
     black: 'hsl(0, 0%, 0%)',
     neutral: {
-        900: 'hsl(350, 10%, 11%)',
-        750: 'hsl(0, 5%, 20%)',
+        900: 'hsl(350, 11%, 11%)',
+        800: 'hsl(0, 11%, 16%)',
+        750: 'hsl(0, 6%, 20%)',
         650: 'hsl(353, 5%, 29%)',
         550: 'hsl(0, 2%, 38%)',
         350: 'hsl(0, 1%, 55%)',
         200: 'hsl(0, 1%, 73%)',
-        50: 'hsl(0, 2%, 91%)'
+        50: 'hsl(0, 2%, 91%)',
+        10: 'hsl(0, 2%, 96%)'
     },
     primary: {
         1100: 'hsl(341, 100%, 13%)',
@@ -217,7 +219,7 @@ export const SemanticColors = {
         '3': Colors.primary[350],
         '4': Colors.primary[500],
         '5': Colors.primary[950],
-        '6': Colors.primary[1100],
+        '6': Colors.primary[1100]
     }
 } satisfies SemanticColorsSchema;
 
@@ -382,7 +384,7 @@ export const SemanticColorsDarkSchema = {
         '3': Colors.primary[150],
         '4': Colors.primary[350],
         '5': Colors.primary[500],
-        '6': Colors.primary[950],
+        '6': Colors.primary[950]
     }
 } satisfies SemanticColorsSchema;
 

--- a/src/essentials/Colors/ModernColors.ts
+++ b/src/essentials/Colors/ModernColors.ts
@@ -101,9 +101,9 @@ export const SemanticColors = {
         }
     },
     background: {
-        default: Colors.neutral[10],
         page: {
             default: Colors.white,
+            'elevation-0': Colors.neutral[10],
             'elevation-1': Colors.white,
             'elevation-2': Colors.white,
             'elevation-3': Colors.white
@@ -173,13 +173,6 @@ export const SemanticColors = {
             }
         },
         backdrop: Colors.neutral[900]
-    },
-    surface: {
-        default: Colors.white,
-        container: {
-            default: Colors.neutral[10],
-            highest: Colors.white
-        }
     },
     border: {
         accent: {
@@ -274,9 +267,9 @@ export const SemanticColorsDarkSchema = {
         }
     },
     background: {
-        default: Colors.neutral[900],
         page: {
-            default: Colors.neutral[900],
+            default: Colors.neutral[800],
+            'elevation-0': Colors.neutral[900],
             'elevation-1': Colors.neutral[750],
             'elevation-2': Colors.neutral[650],
             'elevation-3': Colors.neutral[550]
@@ -346,13 +339,6 @@ export const SemanticColorsDarkSchema = {
             }
         },
         backdrop: Colors.neutral[50]
-    },
-    surface: {
-        default: Colors.neutral[800],
-        container: {
-            default: Colors.neutral[750],
-            highest: Colors.neutral[650]
-        }
     },
     border: {
         accent: {

--- a/src/essentials/Colors/types.ts
+++ b/src/essentials/Colors/types.ts
@@ -9,11 +9,12 @@ export type SemanticColorsSchema = {
     white: Color;
     black: Color;
     background: {
+        default: Color;
         page: {
-            default: Color;
-            'elevation-1': Color;
-            'elevation-2': Color;
-            'elevation-3': Color;
+            default: Color; // deprecated - use background.default or surface.default instead
+            'elevation-1': Color; // deprecated - use surface.container.default instead
+            'elevation-2': Color; // deprecated - use surface.container.highest instead
+            'elevation-3': Color; // deprecated
         };
         backdrop: Color;
         // for big areas
@@ -81,6 +82,13 @@ export type SemanticColorsSchema = {
                 faded: Color;
                 emphasized: Color;
             };
+        };
+    };
+    surface: {
+        default: Color;
+        container: {
+            default: Color;
+            highest: Color;
         };
     };
     border: {

--- a/src/essentials/Colors/types.ts
+++ b/src/essentials/Colors/types.ts
@@ -9,12 +9,12 @@ export type SemanticColorsSchema = {
     white: Color;
     black: Color;
     background: {
-        default: Color;
         page: {
-            default: Color; // deprecated - use background.default or surface.default instead
-            'elevation-1': Color; // deprecated - use surface.container.default instead
-            'elevation-2': Color; // deprecated - use surface.container.highest instead
-            'elevation-3': Color; // deprecated
+            default: Color;
+            'elevation-0': Color;
+            'elevation-1': Color;
+            'elevation-2': Color;
+            'elevation-3': Color;
         };
         backdrop: Color;
         // for big areas
@@ -82,13 +82,6 @@ export type SemanticColorsSchema = {
                 faded: Color;
                 emphasized: Color;
             };
-        };
-    };
-    surface: {
-        default: Color;
-        container: {
-            default: Color;
-            highest: Color;
         };
     };
     border: {


### PR DESCRIPTION
## What
Our designer asked us to add two new neutral base colors to the modern theme and add new semantic colors while deprecating others.

### Media
<img width="1160" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/dce17c91-f11c-4a90-8e31-2929e5f00b24">

<img width="400" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/18f80eea-8fef-4b42-8f97-7f44a4cda090">

<img width="400" alt="image" src="https://github.com/freenowtech/wave/assets/2736136/53ba6f45-91da-4f6c-955e-acf83357f5aa">

## Why
We are redefining the background and surface tokens and will need these extra tones. (neutral-10, neutral-800)

## How
- Add new colors and correct the existing neutral colors (some they were slightly off but it's not significant so should't be considered a breaking change).
- Add new semantic color `background-page-elevation-0`
- Change color for `background-page-default` slightly 