### PR TITLE
feat: add util to enforce a color scheme on an html element

### DIFF
--- a/docs/migrating.storybook.mdx
+++ b/docs/migrating.storybook.mdx
@@ -1,9 +1,9 @@
 import { Meta } from '@storybook/blocks';
 
-import { PlacementMappingsTable } from './components/migration/PlacementMappingsTable';
-import { InvertedPropMigrationTable } from './components/migration/InvertedPropMigrationTable';
-import { IconMappingsTable } from './components/migration/IconMappingsTable';
 import { CssVariablesMigrationTable } from './components/migration/CssVariablesMigrationTable';
+import { IconMappingsTable } from './components/migration/IconMappingsTable';
+import { InvertedPropMigrationTable } from './components/migration/InvertedPropMigrationTable';
+import { PlacementMappingsTable } from './components/migration/PlacementMappingsTable';
 
 <Meta title="Migration to v2" />
 
@@ -80,22 +80,29 @@ In case it doesn't work, reach out to the #ask-wave Slack channel for help.
 Wave v2 comes with automatic dark scheme enabled by default. That means the color of the UI will reflect the OS color preferences of the user.
 
 Most likely, your app will need adjustments to make the dark scheme readable.
-Consider adding a task to your backlog, and disable the dark scheme by wrapping your application root with the `LightScheme` until you are ready:
+Consider adding a task to your backlog, and disable the dark scheme by adding the `wave` and `light-scheme` classes to the body of your app.
 
 ```tsx
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
-import { ClassicColors, LightScheme } from '@freenow/wave'; // blue primary color
+<body class="wave light-scheme">
+    <!-- APP -->
+</body>
+```
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-        <ClassicColors />
-        <LightScheme>
-            <App />
-        </LightScheme>
-    </React.StrictMode>
-);
+In case you cannot access the `body` directly (e.g. NextJS projects) Wave exposes the `enforceSchemeOnElement` utility to programmatically enforce a color scheme for an element.
+
+```tsx
+import { enforceSchemeOnElement } from '@freenow/wave';
+
+export const App = () => {
+    useEffect(() => {
+        const body = document.querySelector('body');
+        if (body) enforceSchemeOnElement('light-scheme', body);
+    }, []);
+
+    return {
+        /* YOUR APP */
+    };
+};
 ```
 
 ## 5️⃣ Polish the code

--- a/src/components/ColorScheme/docs/DarkScheme.stories.tsx
+++ b/src/components/ColorScheme/docs/DarkScheme.stories.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
-import { DarkScheme, LightScheme } from '../EnforcedColorScheme';
-import { Text } from '../../Text/Text';
+import React, { useEffect } from 'react';
+import { enforceSchemeOnElement } from '../../../utils';
+import { Box } from '../../Box/Box';
 import { Button } from '../../Button/Button';
+import { Text } from '../../Text/Text';
+import { DarkScheme, LightScheme } from '../EnforcedColorScheme';
 import { InvertedColorScheme } from '../InvertedColorScheme';
 
 const meta: Meta = {
@@ -57,4 +59,23 @@ export const InvertedColorSchemeWithButton: Story = {
             {children}
         </InvertedColorScheme>
     )
+};
+
+export const ProgrammaticDarkSchemeWithButton: Story = {
+    args: {
+        children: <Button>The box around me is dark!</Button>,
+        py: 2
+    },
+    render: ({ children, ...props }) => {
+        useEffect(() => {
+            const boxElement = document.querySelector('#box-to-enforce-scheme');
+            if (boxElement) enforceSchemeOnElement('dark-scheme', boxElement);
+        }, []);
+
+        return (
+            <Box {...props} id="box-to-enforce-scheme" textAlign="center">
+                {children}
+            </Box>
+        );
+    }
 };

--- a/src/components/ColorScheme/docs/DarkScheme.storybook.mdx
+++ b/src/components/ColorScheme/docs/DarkScheme.storybook.mdx
@@ -2,8 +2,8 @@ import { Meta, Story } from '@storybook/blocks';
 
 import { Source } from '../../../docs/Source';
 import { Box } from '../../Box/Box';
-import * as DarkSchemeStories from './DarkScheme.stories';
 import { CurrentScheme } from './CurrentScheme';
+import * as DarkSchemeStories from './DarkScheme.stories';
 
 <Meta of={DarkSchemeStories} />
 
@@ -12,7 +12,7 @@ import { CurrentScheme } from './CurrentScheme';
 All components in Wave automatically adapts to the users preferred color scheme.
 
 There are situations where you want to force a specific color scheme to a component, or a group of components.
-Wave provides a few components to help you with this.
+Wave provides a few options to help you with this.
 
 ## Invert Color Scheme
 
@@ -51,3 +51,24 @@ Demo:
 ## Props
 
 All components accept [`Box` props](/docs/components-box--docs).
+
+## Programmatically enforcing a Scheme
+
+In case the above components don't fit your use case Wave offers an `enforceSchemeOnElement` utility as an escape hatch to enforce a color scheme for a passed HTML Element.
+
+> The main use case for it is when you want to enforce a scheme for an element that you cannot access through JSX/HTML and need to do it thorugh JS.
+
+<Story of={DarkSchemeStories.ProgrammaticDarkSchemeWithButton} />
+
+```tsx
+useEffect(() => {
+    const boxElement = document.querySelector('#box-to-enforce-scheme');
+    if (boxElement) enforceSchemeOnElement('dark-scheme', boxElement);
+}, []);
+
+return (
+    <Box {...props} id="box-to-enforce-scheme" textAlign="center">
+        {children}
+    </Box>
+);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export * from './components';
 export * from './essentials';
-export * from './icons';
 export * from './hooks';
-export { get as themeGet } from './utils/themeGet';
-export { getSemanticValue } from './utils/cssVariables';
+export * from './icons';
+export * from './utils';

--- a/src/utils/enforceSchemeOnElement.ts
+++ b/src/utils/enforceSchemeOnElement.ts
@@ -1,0 +1,2 @@
+export const enforceSchemeOnElement = (scheme: 'light-scheme' | 'dark-scheme', element: Element): void =>
+    element.classList.add('wave', scheme);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export { getSemanticValue } from './cssVariables';
+export { enforceSchemeOnElement } from './enforceSchemeOnElement';
+export { get as themeGet } from './themeGet';


### PR DESCRIPTION
## What

Adds an `enforceSchemeOnElement` util to enforce a color scheme on a passed element

### Media

Part of migration docs

<img width="1042" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/213f960e-81fa-4999-8092-056c7f5f18ad">

Color scheme docs

<img width="1028" alt="image" src="https://github.com/freenowtech/wave/assets/46452321/3ac6ee67-35a6-461b-86b6-664ac4802089">

## Why

Most projects migrating to Wave 2 are enforcing the light color scheme because they are not yet prepared for the dark scheme, they do that by wrapping their app with a `LightScheme` component (as stated in our previous docs). The issue there is that the `LightScheme` will be rendered below the HTML `body`, so the background and color of the `body` will still follow the user OS preferences, instead of the manual override by the developer.

## How

- Add `enforceSchemeOnElement` util
- Adapt migration docs to use the new util when the dev wants to enforce a color scheme
- Add docs about the util in the color scheme docs
