### PR TITLE
fix(Pagination): Stop clipping two digit page sizes with fixed width

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -135,7 +135,7 @@ const Pagination: React.FC<PaginationProps> = ({
         <Container>
             <ButtonsContainer>
                 {hasMultiplePageSizes && (
-                    <Box aria-label={ariaLabelSelectPageSizeContainer} position="absolute" left="0" width="4.5em">
+                    <Box aria-label={ariaLabelSelectPageSizeContainer} position="absolute" left="0">
                         <SelectList
                             options={pageSizes}
                             onChange={onSelectPageSize}


### PR DESCRIPTION
## What
Removes fixed width of Pagination page size selector, to avoid clipping the page size number

### Media

​_Before_
<img width="922" alt="Screenshot 2024-07-23 at 14 52 55" src="https://github.com/user-attachments/assets/1e431e65-d4c6-449a-8af0-ba9e3c422d3e">

​_After_
<img width="141" alt="Screenshot 2024-07-23 at 14 56 28" src="https://github.com/user-attachments/assets/33726b78-d82b-4c58-8542-6ce224353c95">



## Why
We had reports from DMT that page size is not visible with 2+ digits number.

