### PR TITLE
feat: add exports for experimental components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,29 @@
 {
     "name": "@freenow/wave",
-    "version": "2.5.0",
+    "version": "2.6.0-rc.8",
     "description": "React components of the Wave design system for your Front-End project",
     "main": "lib/cjs/index.js",
     "typings": "lib/types/index.d.ts",
     "module": "lib/esm/index.js",
+    "exports": {
+        ".": {
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js",
+            "default": "./lib/esm/index.js"
+        },
+        "./experimental": {
+            "import": "./lib/esm/experimental/index.js",
+            "require": "./lib/cjs/experimental/index.js",
+            "default": "./lib/esm/experimental/index.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "experimental": [
+                "lib/types/experimental/index.d.ts"
+            ]
+        }
+    },
     "bin": {
         "run_v2_migration": "./scripts/run_v2_migration.sh"
     },
@@ -44,8 +63,7 @@
         "url": "https://github.com/freenowtech/wave.git"
     },
     "files": [
-        "lib/",
-        "codemods/"
+        "lib/"
     ],
     "license": "Apache-2.0",
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
         "url": "https://github.com/freenowtech/wave.git"
     },
     "files": [
-        "lib/"
+        "lib/",
+        "codemods/"
     ],
     "license": "Apache-2.0",
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@freenow/wave",
-    "version": "2.6.0-rc.8",
+    "version": "2.5.0",
     "description": "React components of the Wave design system for your Front-End project",
     "main": "lib/cjs/index.js",
     "typings": "lib/types/index.d.ts",

--- a/src/essentials/experimental/index.ts
+++ b/src/essentials/experimental/index.ts
@@ -1,0 +1,1 @@
+export * from './theme';

--- a/src/essentials/experimental/index.ts
+++ b/src/essentials/experimental/index.ts
@@ -1,1 +1,2 @@
 export * from './theme';
+export { createGlobalStyle, ColorPalette } from './Colors';

--- a/src/essentials/experimental/theme.ts
+++ b/src/essentials/experimental/theme.ts
@@ -1,5 +1,5 @@
 import { DefaultTheme } from 'styled-components';
-import { Spaces, Breakpoints, MediaQueries } from '../index';
+import { Breakpoints, MediaQueries } from '../index';
 
 const ExperimentalSpaces = [
     '0', // 0
@@ -24,7 +24,7 @@ interface ExperimentalFontWeights {
     bold: number;
 }
 
-export interface ExperimentalTheme extends DefaultTheme {
+interface ExperimentalTheme extends DefaultTheme {
     lineHeights: string[];
     fontWeights: ExperimentalFontWeights;
     chips: any;
@@ -109,4 +109,4 @@ function fontStack(fonts: string[]): string {
     return fonts.map(font => (font.includes(' ') ? `"${font}"` : font)).join(', ');
 }
 
-export { theme };
+export { theme, ExperimentalTheme };

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -1,0 +1,2 @@
+export * from '../components/experimental';
+export * from '../essentials/experimental';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components';
 export * from './essentials';
+export * as experimental from './experimental';
 export * from './hooks';
 export * from './icons';
 export * from './utils';


### PR DESCRIPTION
## What

Adds exports for the `experimental` folder, so that when distributing the package it can be accessed directly.

### Media

Now the experimental components can be accessed like:
```typescript
import { Button, Chip } from '@freenow/wave/experimental'
``` 


## Why

To allow to directly access experimental features, without needing to know the internal file structure of the package.


## How

- Adds [exports](https://nodejs.org/api/packages.html#exports) field in package.json to define the default + the experimental exports
- Adds `typesVersions` field to package.json to override the `experimental` types (so they don't come from the main index.d.ts file)

## Extra

I'm opening this as a draft PR because the experimental components are not ready to be distributed yet, once we have a first experimental component we can merge this.

I've already tested this approach in several `rc` releases, if you want to try it out as well you can check [2.6.0-rc.8](https://www.npmjs.com/package/@freenow/wave/v/2.6.0-rc.8). I've rolled back the version in package.json so that it gets automatically updated by semantic-release once the PR is merged.

The linting issues that you see are due to comments in some experimental components, those should be solved as part of the PRs for each component.
