### PR TITLE
docs: update maintainers, codeowners, codesandbox, readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,9 +5,12 @@ about: Bugs, missing documentation, or unexpected behavior 🤔.
 
 <!--
 
-* Please fill out this template with all the relevant information so we can
+* Please fill out this template with all the relevant information, so we can
   understand what's going on and fix the issue. We appreciate bugs filed and PRs
   submitted!
+* If you are opening reporting a bug specific to one of the FREENOW webapps,
+  please consider adding it to the internal backlog instead!
+  More info in #ask-wave via Slack.
 
 -->
 
@@ -16,7 +19,7 @@ about: Bugs, missing documentation, or unexpected behavior 🤔.
 ### Relevant code
 
 ```js
-var your => (code) => here;
+const your = code => here;
 ```
 
 ### What was expected to happen?
@@ -27,5 +30,5 @@ var your => (code) => here;
 
 <!--
 If you can, try to reproduce the issue in a Codesandbox. You can fork the one
-here: https://codesandbox.io/s/wave-playground-w7cf3 (make sure to use latest Wave version)
+here: https://stackblitz.com/edit/fn-wave-playground?file=src%2FApp.tsx (make sure to use the related Wave version)
 -->

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @martimalek @jonotrujillo @arturmiglio @dornelasnelson @JanHamara 
+* @jonotrujillo @arturmiglio @dornelasnelson

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
     -   [Your First Contribution](#your-first-contribution)
         -   [Triage tickets](#triage-tickets)
         -   [Write some documentation](#write-some-documentation)
-        -   [Reporting pains and use cases](#reporting-pains-and-use-cases)
+        -   [Give us your feedback](#give-us-your-feedback)
         -   [Take from the backlog](#take-from-the-backlog)
     -   [Tools we use](#tools-we-use)
     -   [Component patterns](#component-patterns)
@@ -98,11 +98,11 @@ You can serve your self with CI tools to make easier the creation of commits wit
 
 ### Triage tickets
 
-If an unreviewed ticket reports a bug, try and reproduce it. If you can reproduce it and it seems valid, make a note that you confirmed the bug and accept the ticket. A video or clear steps on how to reproduce a bug is a great way to setup the ground for the next dev
+If an unreviewed ticket reports a bug, try and reproduce it. If you can reproduce it, and it seems valid, make a note that you confirmed the bug and accept the ticket. A video or clear steps on how to reproduce a bug is a great way to set up the ground for the next dev.
 
 ### Write some documentation
 
-Our documentation is great but it can always be improved. Did you find a typo? Do you think that something should be clarified? Go ahead and suggest a documentation patch!
+Our documentation is great, but it can always be improved. Did you find a typo? Do you think that something should be clarified? Go ahead and suggest a documentation patch!
 
 We use [Storybook](https://storybook.js.org) to run our documentation site at [wave.free-now.com](https://wave.free-now.com/).
 
@@ -113,20 +113,22 @@ To add a new component to our documentation site:
 
 To learn more how to add stories go to [Storybook docs](https://storybook.js.org/docs/react/writing-stories/introduction)
 
-### Reporting pains and use cases
+### Give us your feedback
 
-Speak out loud for us to understand your pains is valuable, challenge current approaches and help us to understand how to do better. Make sure to verify that the topic hasn't being touched yet on the issues poll otherwise open a new one and let's start the conversation
+Feedback, feedback, feedback! We appreciate and need your input to understand your needs, so we can continue delivering great value.
+If you don't know where to start from, first check with a similar issue is not already created, otherwise create a new one.
+Also, make sure to share it in our internal channel, so we can discuss effort, impact and priority: #ask-wave.
 
 ### Take from the backlog
 
-Feel like doing a bit more? You can check what is up for grabs in our public backlog and create a PR for it
+Feel like doing a bit more? You can check what is up for grabs in our public backlog and create a PR for it. All contributions are welcomed!
 
 ## Distribution channels
 
-We use [semantic release](https://semantic-release.gitbook.io/semantic-release) to automate our versioning and release process. Currently we have 3 distribution channels:
+We use [semantic release](https://semantic-release.gitbook.io/semantic-release) to automate our versioning and release process. Currently, we have 3 distribution channels:
 
 -   `latest` tag (follows the [main](https://github.com/freenowtech/wave/tree/main) branch): It is used for releases on the current major (v2)
--   `next` tag (follows the [next](https://github.com/freenowtech/wave/tree/next) branch): It is used for prereleases on the next major (v3)
+-   `next` tag (follows the [next](https://github.com/freenowtech/wave/tree/next) branch): It is used for pre-releases on the next major (v3)
 -   `release-1.34.x` tag (follows the [1.34.x](https://github.com/freenowtech/wave/tree/1.34.x) branch): It is used to provide maintenance on our previous major version (v1). For more information check [semantic-release maintenance releases guide](https://semantic-release.gitbook.io/semantic-release/recipes/release-workflow/maintenance-releases)
 
 ## Tools we use

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,14 +1,16 @@
 # Maintainers
 
--   [Rafael Sepeda Errera](https://github.com/rafael-sepeda)
--   [Nikolai Lopin](https://github.com/nlopin)
--   [Leonardo Di Vittorio](https://github.com/div-Leo)
 -   [Jonathan Trujillo Pineros](https://github.com/jonotrujillo)
 -   [Lloyd Francis](https://github.com/lloydaf)
--   [Martí Malek](https://github.com/martimalek)
+-   [Artur Miglio](https://github.com/arturmiglio)
+-   [Nelson Dornelas](https://github.com/dornelasN)
 
 # Acknowledgment
 
+-   [Rafael Sepeda Errera](https://github.com/rafael-sepeda)
+-   [Nikolai Lopin](https://github.com/nlopin)
+-   [Leonardo Di Vittorio](https://github.com/div-Leo)
+-   [Martí Malek](https://github.com/martimalek)
 -   [Jonah Möller](https://github.com/snapsnapturtle)
 -   [Luka Hartwig](https://github.com/lukahartwig)
 -   [Alexis Duran](https://github.com/duranmla)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ or
 yarn add @freenow/wave
 ```
 
+## Getting started
+
+After installing Wave as dependency, there are some extra steps to get the styles in place:
+
+-   Make sure to install the peerDependencies (including styled-components)
+-   Check that you don't have any pre-existing global styles that might override/clash with the styles shipped with the components (ex.: `a { color: #ffeeaa }`)
+-   Make sure to add the desired Color Scheme component to your React tree, to get the CSS variables loaded ([more details](https://wave.free-now.com/iframe.html?viewMode=docs&id=migration-to-v2--docs#1%EF%B8%8F%E2%83%A3-connect-classic-colors))
+
+```typescript jsx
+import { ModernColors } from '@freenow/wave'; // blue primary color
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+        <ModernColors />
+        <App />
+    </React.StrictMode>
+);
+```
+
 ## Contributing
 
 Thanks for being willing to contribute! Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) doc


### PR DESCRIPTION
## What

* Update several parts of the docs and codeowners/maintainers.

* Added a notice about the Color Scheme in the install instructions (Wave >2.x now doesn't work out-of-the-box without it).

* Replace the code sandbox provided in the bug report template, to a new one made with StackBlitz, in order to use Vite as the build tool, and with latest version of Wave.

### Media​

[README](https://github.com/freenowtech/wave/blob/ad0fded287e766c9d3f8bb571f6f60ad0c9ce1fd/README.md)

[CONTRIBUTING](https://github.com/freenowtech/wave/blob/ad0fded287e766c9d3f8bb571f6f60ad0c9ce1fd/CONTRIBUTING.md)

[MAINTAINERS](https://github.com/freenowtech/wave/blob/ad0fded287e766c9d3f8bb571f6f60ad0c9ce1fd/MAINTAINERS.md)
​
