### PR TITLE
fix: fix overflow in popover

### DIFF
--- a/src/components/experimental/ComboBox/ComboBox.tsx
+++ b/src/components/experimental/ComboBox/ComboBox.tsx
@@ -27,6 +27,7 @@ const defaultAriaStrings = {
 
 const StyledPopover = styled(Popover)`
     box-sizing: border-box;
+    overflow: auto;
     width: var(--trigger-width);
 `;
 

--- a/src/components/experimental/Select/Select.tsx
+++ b/src/components/experimental/Select/Select.tsx
@@ -24,6 +24,7 @@ import { fieldStyles, fieldTextStyles } from '../Field/Field';
 
 const StyledPopover = styled(Popover)`
     box-sizing: border-box;
+    overflow: auto;
     width: var(--trigger-width);
 `;
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->


## What

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->


Fixes displaying overflowing content in Combobox' and Select' popovers


### Media

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

<img width="614" alt="Screenshot 2024-10-15 at 13 26 28" src="https://github.com/user-attachments/assets/1908f9fa-d3b0-4978-a954-8aeac49d0c4b">


## Why

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->

​<img width="328" alt="Screenshot 2024-10-15 at 13 26 55" src="https://github.com/user-attachments/assets/3db56923-4096-454b-8f7a-49c9a0618114">

## How

<!-- Often a list of things to describe the process to accomplish this PR -->
