### PR TITLE
fix: popover and listboxitem styling

### DIFF
--- a/src/components/experimental/ComboBox/ComboBox.tsx
+++ b/src/components/experimental/ComboBox/ComboBox.tsx
@@ -27,9 +27,7 @@ const defaultAriaStrings = {
 };
 
 const StyledPopover = styled(Popover)`
-    box-sizing: border-box;
     overflow: auto;
-    width: var(--trigger-width);
 `;
 
 interface ComboBoxFieldProps extends Pick<FieldProps, 'label' | 'description' | 'errorMessage' | 'leadingIcon'> {

--- a/src/components/experimental/IconButton/IconButton.tsx
+++ b/src/components/experimental/IconButton/IconButton.tsx
@@ -25,6 +25,7 @@ const StandardIconContainer = styled(Button)<Omit<IconButtonProps, 'Icon'>>`
     &[data-disabled],
     &[data-pending] {
         cursor: not-allowed;
+        opacity: 0.38;
     }
 
     /* we create a before pseudo element to mess with the opacity (see the hovered state) */
@@ -50,11 +51,6 @@ const StandardIconContainer = styled(Button)<Omit<IconButtonProps, 'Icon'>>`
     &:not([data-disabled]) {
         color: ${props => (props.isActive ? getSemanticValue('interactive') : getSemanticValue('on-surface'))};
     }
-
-    &[data-disabled],
-    &[data-pending] {
-        opacity: 0.38;
-    }
 `;
 
 const TonalIconContainer = styled(Button)<Omit<IconButtonProps, 'Icon'>>`
@@ -69,6 +65,7 @@ const TonalIconContainer = styled(Button)<Omit<IconButtonProps, 'Icon'>>`
     &[data-disabled],
     &[data-pending] {
         cursor: not-allowed;
+        opacity: 0.38;
     }
 
     /* we create a before pseudo element to mess with the opacity (see the hovered state) */
@@ -103,11 +100,6 @@ const TonalIconContainer = styled(Button)<Omit<IconButtonProps, 'Icon'>>`
     &:not([data-disabled]) {
         color: ${props =>
             props.isActive ? getSemanticValue('on-interactive-container') : getSemanticValue('on-surface')};
-    }
-
-    &[data-disabled],
-    &[data-pending] {
-        opacity: 0.38;
     }
 `;
 

--- a/src/components/experimental/ListBox/ListBox.tsx
+++ b/src/components/experimental/ListBox/ListBox.tsx
@@ -7,6 +7,7 @@ import { getSemanticValue } from '../../../essentials/experimental';
 
 const StyledListBoxItem = styled(BaseListBoxItem)`
     position: relative;
+    display: block;
     padding: ${get('space.3')} ${get('space.4')};
     border-radius: ${get('radii.4')};
     color: ${getSemanticValue('on-surface')};

--- a/src/components/experimental/Popover/Popover.tsx
+++ b/src/components/experimental/Popover/Popover.tsx
@@ -15,8 +15,8 @@ const StyledPopover = styled(BasePopover)`
         0 4px 5px 0 hsla(0, 0%, 0%, 0.14);
     border-radius: ${get('radii.4')};
 
-    [data-trigger='Select'],
-    [data-trigger='ComboBox'] {
+    &[data-trigger='Select'],
+    &[data-trigger='ComboBox'] {
         box-sizing: border-box;
         width: var(--trigger-width);
     }

--- a/src/components/experimental/Popover/Popover.tsx
+++ b/src/components/experimental/Popover/Popover.tsx
@@ -14,6 +14,12 @@ const StyledPopover = styled(BasePopover)`
     box-shadow: 0 2px 4px -1px hsla(0, 0%, 0%, 0.2), 0 1px 10px 0 hsla(0, 0%, 0%, 0.12),
         0 4px 5px 0 hsla(0, 0%, 0%, 0.14);
     border-radius: ${get('radii.4')};
+
+    [data-trigger='Select'],
+    [data-trigger='ComboBox'] {
+        box-sizing: border-box;
+        width: var(--trigger-width);
+    }
 `;
 
 const FocusTrap = styled(Dialog)`

--- a/src/components/experimental/Select/Select.tsx
+++ b/src/components/experimental/Select/Select.tsx
@@ -24,9 +24,7 @@ import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import { fieldStyles, fieldTextStyles } from '../Field/Field';
 
 const StyledPopover = styled(Popover)`
-    box-sizing: border-box;
     overflow: auto;
-    width: var(--trigger-width);
 `;
 
 const FakeButton = styled(FakeInput)`


### PR DESCRIPTION
<!--
Thanks for your interest in the project!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->

1. Moves the "width = trigger-width" styling into the popover
2. When a listbox item has a `href` it's rendered as an `a`, which is a phrasing content by default

### Media

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

​
​Illustrates both issues
<img width="240" alt="Screenshot 2024-11-11 at 11 23 17" src="https://github.com/user-attachments/assets/e0ad07ea-f9fb-4881-838a-43e2a0b45480">


## Why

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->

https://jira.intapps.it/browse/DISP-316

## How

<!-- Often a list of things to describe the process to accomplish this PR -->
