### PR TITLE
feat(select): add value customisation

### DIFF
--- a/src/components/experimental/Select/docs/Select.stories.tsx
+++ b/src/components/experimental/Select/docs/Select.stories.tsx
@@ -70,3 +70,9 @@ export const Invalid: Story = {
         errorMessage: 'Error'
     }
 };
+
+export const WithCustomValueRenderer: Story = {
+    args: {
+        renderValue: ({ selectedText, isPlaceholder }) => (isPlaceholder ? '' : `${selectedText} ♥`)
+    }
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->

Adds customisation ability for the Select value

### Media

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

<img width="326" alt="Screenshot 2024-11-18 at 18 10 12" src="https://github.com/user-attachments/assets/ba22ae8d-27d6-46cf-a852-66a7ca30ea60">

## Why

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->

Normally, select works like WYSIWYG: the user selects an item in the list and it is displayed as a select value

​Scenario: we might show additional information in the list (Fleet label + fare + ETA), but still want to display only the label as the value, when the item is selected

## How

<!-- Often a list of things to describe the process to accomplish this PR -->

Introducing the `renderValue` prop
