### PR TITLE
fix: pass rest props to the icon button container

### DIFF
--- a/src/components/experimental/IconButton/IconButton.tsx
+++ b/src/components/experimental/IconButton/IconButton.tsx
@@ -109,7 +109,8 @@ export const IconButton = ({
     isLoading = false,
     Icon,
     variant = 'standard',
-    onPress
+    onPress,
+    ...restProps
 }: IconButtonProps): ReactElement => {
     const Container = variant === 'standard' ? StandardIconContainer : TonalIconContainer;
 
@@ -120,6 +121,7 @@ export const IconButton = ({
             isDisabled={isDisabled}
             isActive={isActive}
             isPending={isLoading}
+            {...restProps}
         >
             {isLoading ? (
                 <InlineSpinner data-testid="iconbutton-spinner" color={getSemanticValue('on-surface')} />


### PR DESCRIPTION
## What

Spread `restProps` into the button element so it receives additional properties such as `arial-label`

### Media

<img width="948" alt="icon-button-aria-label" src="https://github.com/user-attachments/assets/8990ae60-281c-4547-b975-7e75bd8610d4">

## Why

The experimental icon button is not handling needed properties such as `aria-label`
​
