### PR TITLE
feat: add snackbar component

### DIFF
--- a/src/components/experimental/Snackbar/Snackbar.tsx
+++ b/src/components/experimental/Snackbar/Snackbar.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode, type ReactElement } from 'react';
+import styled from 'styled-components';
+import { SpaceProps, LayoutProps, PositionProps, FlexboxProps } from 'styled-system';
+
+import { get } from '../../../utils/experimental/themeGet';
+import { getSemanticValue } from '../../../essentials/experimental';
+import { textStyles } from '../Text/Text';
+
+const Container = styled.div`
+    position: relative;
+    justify-content: space-between;
+
+    border: none;
+    outline: none;
+    border-radius: ${get('radii.4')};
+    padding: ${get('space.4')} ${get('space.5')};
+    color: ${getSemanticValue('inverse-on-surface')};
+    background-color: ${getSemanticValue('inverse-surface')};
+
+    display: inline-flex;
+    align-items: center;
+    gap: ${get('space.1')};
+
+    ${textStyles.variants.body2}
+`;
+
+interface SnackbarProps extends SpaceProps, LayoutProps, PositionProps, FlexboxProps {
+    children?: ReactNode;
+}
+
+const Snackbar = ({ children, ...restProps }: SnackbarProps): ReactElement => (
+    <Container {...restProps}>{children}</Container>
+);
+
+export { Snackbar, SnackbarProps };

--- a/src/components/experimental/Snackbar/docs/Snackbar.stories.tsx
+++ b/src/components/experimental/Snackbar/docs/Snackbar.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { Snackbar } from '../Snackbar';
+import { XCrossIcon } from '../../../../icons';
+import { getSemanticValue } from '../../../../essentials/experimental/cssVariables';
+
+const meta: Meta = {
+    title: 'Experimental/Components/Snackbar',
+    component: Snackbar,
+    parameters: {
+        layout: 'centered'
+    },
+    argTypes: {},
+    args: {
+        children: 'Booking successfully cancelled'
+    }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Snackbar>;
+
+export const Default: Story = {};
+
+export const WithDismissIcon: Story = {
+    args: {
+        children: (
+            <>
+                Booking successfully cancelled
+                <XCrossIcon
+                    cursor="pointer"
+                    size={30}
+                    color={getSemanticValue('on-interactive')}
+                    onClick={action('Remove snackbar')}
+                />
+            </>
+        )
+    }
+};


### PR DESCRIPTION
## What

This PR adds a `Snackbar` component that will be used as part of the UI feedback during the booking cancellation flow of the Dispatcher Tool 

### Media

<img width="732" alt="wave-snackbar" src="https://github.com/user-attachments/assets/5a4edfb2-a05d-4362-916d-0667c7207436">

