### PR TITLE
chore: export snackbar interface

### DIFF
--- a/src/components/experimental/index.ts
+++ b/src/components/experimental/index.ts
@@ -11,7 +11,7 @@ export { Label } from './Label/Label';
 export { ListBox, ListBoxItem } from './ListBox/ListBox';
 export { Popover } from './Popover/Popover';
 export { Select } from './Select/Select';
-export { Snackbar } from './Snackbar/Snackbar';
+export { Snackbar, SnackbarProps } from './Snackbar/Snackbar';
 export { Table, Row, Cell, Skeleton, Column, TableBody, TableHeader } from './Table/Table';
 export { Text } from './Text/Text';
 export { TextField } from './TextField/TextField';


### PR DESCRIPTION
## What

It exports the `Snackbar` interface

## Why

In order to allow extensibility and reusability in implementations






