### PR TITLE
fix: remove prop type overriding and add event type in snackbar

### DIFF
--- a/src/components/experimental/IconButton/IconButton.tsx
+++ b/src/components/experimental/IconButton/IconButton.tsx
@@ -10,7 +10,6 @@ export interface IconButtonProps extends ButtonProps {
     isLoading?: boolean;
     variant?: 'standard' | 'tonal';
     Icon: React.FC<IconProps>;
-    onPress: () => void;
 }
 
 const StandardIconContainer = styled(Button)<Omit<IconButtonProps, 'Icon'>>`

--- a/src/components/experimental/Snackbar/Snackbar.tsx
+++ b/src/components/experimental/Snackbar/Snackbar.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, ReactNode, type ReactElement } from 'react';
+import { PressEvent } from 'react-aria';
 import styled from 'styled-components';
 import { SpaceProps, LayoutProps, PositionProps, FlexboxProps } from 'styled-system';
 
@@ -40,7 +41,7 @@ interface SnackbarProps
         React.HTMLAttributes<HTMLDivElement> {
     children: ReactNode;
     hasDismissButton?: boolean;
-    onDismiss?: () => void;
+    onDismiss?: (e: PressEvent) => void;
 }
 
 const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(


### PR DESCRIPTION
## What

This PR removes the overriding of the `onPress` prop when extending the interface for the `IconButton` component.
It also adds the correct event typing in `Snackbar`


## Why

This override we are removing causes us to lose the event typing inherited from `AriaButtonProps`

