### PR TITLE
feat(modal): remove padding from ModalCard

### DIFF
--- a/src/components/experimental/Dialog/Dialog.tsx
+++ b/src/components/experimental/Dialog/Dialog.tsx
@@ -20,6 +20,7 @@ const ButtonsWrapper = styled.div`
 `;
 
 const StyledModal = styled(Modal)`
+    padding: 2rem;
     width: 30rem;
 `;
 

--- a/src/components/experimental/Modal/Modal.tsx
+++ b/src/components/experimental/Modal/Modal.tsx
@@ -4,7 +4,6 @@ import { Dialog, DialogProps, Modal as BaseModal } from 'react-aria-components';
 import { getSemanticValue } from '../../../essentials/experimental';
 
 const ModalCard = styled(BaseModal)`
-    padding: 2rem;
     border-radius: 1.5rem;
     background: ${getSemanticValue('surface')};
     color: ${getSemanticValue('on-surface')};


### PR DESCRIPTION
Remove dapping to make modals appearance customizable on the project level (we do not have general guidelines what modals should look like yet)