### PR TITLE
feat: add checkboxes support to experimental dialog

### DIFF
--- a/src/components/experimental/Checkbox/Checkbox.tsx
+++ b/src/components/experimental/Checkbox/Checkbox.tsx
@@ -2,12 +2,9 @@ import React, { FC, ReactNode } from 'react';
 import { Checkbox as CheckboxComponent, CheckboxProps as ReactAriaCheckboxProps } from 'react-aria-components';
 import styled from 'styled-components';
 
-import { Text } from '../Text/Text';
+import { Text, TextVariant } from '../Text/Text';
 import { LabelWrapper } from './components/LabelWrapper';
-
 import { getSemanticValue, themeGet } from '../../../experimental';
-
-type TextVariant = 'display' | 'headline' | 'title1' | 'title2' | 'body1' | 'body2' | 'label1' | 'label2';
 
 interface CheckboxProps extends Omit<ReactAriaCheckboxProps, 'children'> {
     /**

--- a/src/components/experimental/Dialog/Dialog.tsx
+++ b/src/components/experimental/Dialog/Dialog.tsx
@@ -19,6 +19,13 @@ const ButtonsWrapper = styled.div`
     gap: 1rem;
 `;
 
+const CheckboxesWrapper = styled.div`
+    padding-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+`;
+
 const StyledModal = styled(Modal)`
     padding: 2rem;
     width: 30rem;
@@ -37,8 +44,9 @@ interface DialogProps extends Omit<BackdropProps, 'isDismissable' | 'isKeyboardD
     role?: 'dialog' | 'alertdialog';
     headline: ReactNode;
     subtitle: ReactNode;
-    dismissButton: ReactNode;
+    dismissButton?: ReactNode;
     actionButton: ReactNode;
+    checkboxes?: ReactNode;
 }
 
 const Dialog = ({
@@ -47,6 +55,7 @@ const Dialog = ({
     subtitle,
     dismissButton,
     actionButton,
+    checkboxes,
     ...props
 }: DialogProps): ReactElement => (
     <Backdrop {...props} isDismissable={false} isKeyboardDismissDisabled>
@@ -57,6 +66,8 @@ const Dialog = ({
                 <SubtitleText as="p" variant="body1">
                     {subtitle}
                 </SubtitleText>
+
+                {checkboxes && <CheckboxesWrapper>{checkboxes}</CheckboxesWrapper>}
 
                 <ButtonsWrapper>
                     {dismissButton}

--- a/src/components/experimental/Dialog/docs/Dialog.stories.tsx
+++ b/src/components/experimental/Dialog/docs/Dialog.stories.tsx
@@ -1,9 +1,18 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+
 import { Dialog } from '../Dialog';
 import { Button } from '../../Button/Button';
 import { WarningIcon } from '../../../../icons';
+import { Checkbox } from '../../Checkbox/Checkbox';
+import { getSemanticValue } from '../../../../experimental';
+
+const StyledLink = styled.a`
+    color: ${getSemanticValue('accent')};
+    text-decoration: underline;
+`;
 
 const meta: Meta = {
     title: 'Experimental/Components/Dialog',
@@ -78,6 +87,76 @@ export const Alert: Story = {
                             Try again
                         </Button>
                     }
+                />
+            </>
+        );
+    }
+};
+
+export const WithCheckboxes: Story = {
+    render: () => {
+        const [isOpen, setIsOpen] = useState(false);
+        const [termsChecked, setTermsChecked] = useState(false);
+        const [privacyChecked, setPrivacyChecked] = useState(false);
+        const [termsInvalid, setTermsInvalid] = useState(false);
+        const [privacyInvalid, setPrivacyInvalid] = useState(false);
+
+        const handleProceed = () => {
+            if (termsChecked && privacyChecked) {
+                action('Action - Both accepted')();
+                setIsOpen(false);
+            } else {
+                if (!termsChecked) setTermsInvalid(true);
+                if (!privacyChecked) setPrivacyInvalid(true);
+                action('Action - Validation failed')();
+            }
+        };
+
+        const handleTermsChange = (isSelected: boolean) => {
+            setTermsChecked(isSelected);
+            if (isSelected) setTermsInvalid(false);
+        };
+
+        const handlePrivacyChange = (isSelected: boolean) => {
+            setPrivacyChecked(isSelected);
+            if (isSelected) setPrivacyInvalid(false);
+        };
+
+        return (
+            <>
+                <Button onPress={() => setIsOpen(true)}>Open a dialog</Button>
+                <Dialog
+                    isOpen={isOpen}
+                    onOpenChange={setIsOpen}
+                    headline="Review and Accept: Terms & Privacy"
+                    subtitle="To continue using the Dispatcher tool, please review and accept both our Terms and Conditions and Privacy Policy."
+                    actionButton={<Button onPress={handleProceed}>Proceed</Button>}
+                    checkboxes={[
+                        <Checkbox
+                            key="terms"
+                            isSelected={termsChecked}
+                            onChange={handleTermsChange}
+                            isInvalid={termsInvalid}
+                            label={
+                                <>
+                                    I have read and agree to FREENOW&apos;s
+                                    <StyledLink href="/terms">Terms and Conditions.</StyledLink>
+                                </>
+                            }
+                        />,
+                        <Checkbox
+                            key="privacy"
+                            isSelected={privacyChecked}
+                            onChange={handlePrivacyChange}
+                            isInvalid={privacyInvalid}
+                            label={
+                                <>
+                                    I have read and agree to FREENOW&apos;s
+                                    <StyledLink href="/terms">Privacy Policy.</StyledLink>
+                                </>
+                            }
+                        />
+                    ]}
                 />
             </>
         );

--- a/src/components/experimental/Text/Text.tsx
+++ b/src/components/experimental/Text/Text.tsx
@@ -3,8 +3,10 @@ import styled from 'styled-components';
 import { compose, ResponsiveValue, variant } from 'styled-system';
 import { theme } from '../../../essentials/experimental';
 
+export type TextVariant = 'display' | 'headline' | 'title1' | 'title2' | 'body1' | 'body2' | 'label1' | 'label2';
+
 interface TextProps extends BaseTextProps {
-    variant?: ResponsiveValue<'display' | 'headline' | 'title1' | 'title2' | 'body1' | 'body2' | 'label1' | 'label2'>;
+    variant?: ResponsiveValue<TextVariant>;
 }
 
 export const textStyles = {


### PR DESCRIPTION
## What

Extends the experimental Dialog component to support checkboxes

### Media

https://github.com/user-attachments/assets/79fd1703-0ebb-4e62-9319-9c945fca4f3e

## Why

Required for GTC acceptance flow SUP-47661​

