### PR TITLE
docs: #548 - Add details about adding styles in the react project root

### DIFF
--- a/docs/get-started.storybook.mdx
+++ b/docs/get-started.storybook.mdx
@@ -26,6 +26,25 @@ To bring the design system into your project, install it as a package:
 npm i @freenow/wave
 ```
 
+## Getting started
+
+After installing Wave as dependency, there are some extra steps to get the styles in place:
+
+-   Make sure to install the peerDependencies (including styled-components)
+-   Check that you don't have any pre-existing global styles that might override/clash with the styles shipped with the components (ex.: `a { color: #ffeeaa }`)
+-   Make sure to add the desired Color Scheme component to your React tree, to get the CSS variables loaded ([more details](https://wave.free-now.com/iframe.html?viewMode=docs&id=migration-to-v2--docs#1%EF%B8%8F%E2%83%A3-connect-classic-colors))
+
+```typescript jsx
+import { ModernColors } from '@freenow/wave'; // blue primary color
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+        <ModernColors />
+        <App />
+    </React.StrictMode>
+);
+```
+
 ## Usage
 
 All of our components are exported by name from `@freenow/wave`, so you can import them with:


### PR DESCRIPTION
## What
Adds missing `ModernColors` setup step to the "Get Started" documentation for https://wave.free-now.com/?path=/docs/get-started--docs page.


## Why
If someone follows the setup instructions on the website without this step, the Wave components appear unstyled, which can create a confusing experience for new users.


## How
Included an example usage of `ModernColors` in the setup guide to ensure proper CSS variables are loaded.