### PR TITLE
fix: remove unreliable :has() selector in InnerWrapper

### DIFF
--- a/src/components/experimental/Field/InnerWrapper.ts
+++ b/src/components/experimental/Field/InnerWrapper.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Label } from './Label';
 
 export const InnerWrapper = styled.div<{ hideLabel?: boolean }>`
     position: relative;
@@ -13,10 +12,4 @@ export const InnerWrapper = styled.div<{ hideLabel?: boolean }>`
         `
         padding-top: var(--wave-exp-typescale-label-2-line-height);
     `}
-
-    /* For browsers that support :has(), we use this as a fallback */
-    /* stylelint-disable selector-type-case, selector-type-no-unknown */
-    &:has(${Label}:not(.visually-hidden)) {
-        padding-top: var(--wave-exp-typescale-label-2-line-height);
-    }
 `;


### PR DESCRIPTION
## What

Removed the CSS `:has()` selector in the `InnerWrapper` component that was incorrectly applying padding even when labels were visually hidden, and the label is required anyways.

## Why

The `:has()` selector was detecting the `Label` component even when they were wrapped in `VisuallyHidden`, causing padding to be applied incorrectly. This resulted in unwanted space at the top of components with hidden labels.

We now rely solely on the prop-based conditional styling (`$hideLabel`), which provides more predictable and consistent behavior across all browsers.
​
