### PR TITLE
feat: make label a required prop on TimeField

### DIFF
--- a/src/components/experimental/TimeField/TimeField.tsx
+++ b/src/components/experimental/TimeField/TimeField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TimeValue, VisuallyHidden } from 'react-aria';
+import { TimeValue } from 'react-aria';
 import { FieldError, TimeField as BaseTimeField, TimeFieldProps as BaseTimeFieldProps } from 'react-aria-components';
 import { Label } from '../Field/Label';
 import { Footer } from '../Field/Footer';
@@ -9,6 +9,7 @@ import { DateInput } from '../Field/Field';
 import { DateSegment } from '../Field/DateSegment';
 import { Wrapper } from '../Field/Wrapper';
 import { FieldProps } from '../Field/Props';
+import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 
 type TimeFieldProps = Omit<FieldProps, 'label'> &
     BaseTimeFieldProps<TimeValue> & {


### PR DESCRIPTION
## What

While writing unit tests for the `TimeGrid` component in the recurrent trip forms, I realized that our `TimeField` component should always have a label for accessibility purposes. 
## Why

This change follows WCAG accessibility guidelines and ensures all users. 
Even when designs call for a minimal UI, we now maintain accessibility by requiring labels while providing the option to visually hide them when necessary.

## How

- Makes the label prop required in `TimeField`
- Adds a `hideLabel` prop to control visual display when needed
- Properly handles visually hidden labels while maintaining accessibility
