### PR TITLE
fix: add missing MonthRangePicker export to components index file

### DIFF
--- a/src/components/MonthPicker/MonthRangePicker.tsx
+++ b/src/components/MonthPicker/MonthRangePicker.tsx
@@ -71,7 +71,7 @@ const Forward = styled(NavButton)`
     right: 1.5rem;
 `;
 
-interface MonthRangePickerProps extends MarginProps, WidthProps {
+export interface MonthRangePickerProps extends MarginProps, WidthProps {
     onRangeSelect?: (start: Date | null, end: Date | null) => void;
     minMonth?: Date;
     maxMonth?: Date;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,6 +22,7 @@ export { Tag, TagProps } from './Tag/Tag';
 export { InlineSpinner, InlineSpinnerProps } from './InlineSpinner/InlineSpinner';
 export { TabBar, TabBarWithLink as TabBarProps } from './TabBar/TabBar';
 export { DatePicker, DateRangePicker, DateRangePickerProps, DatePickerProps, DateRange } from './Datepicker';
+export { MonthRangePicker, MonthRangePickerProps } from './MonthPicker';
 export { Divider, DividerProps } from './Divider/Divider';
 export { Tooltip, TooltipProps } from './Tooltip/Tooltip';
 export { Toggle, ToggleProps } from './Toggle/Toggle';


### PR DESCRIPTION
## What

Add missing MonthRangePicker export

## Why

The new MonthRangePicker can currently not be used, because there is no export from the index file in the components folder
