### PR TITLE
fix(AUT-2298): Bug fix for years that default incorrectly 

### DIFF
--- a/src/components/experimental/DatePicker/util/index.ts
+++ b/src/components/experimental/DatePicker/util/index.ts
@@ -11,7 +11,6 @@ function isCalendarLike(v: unknown): v is CalendarLike {
 
 export function tryParse(raw: string, fmt: string, locale?: Locale): Date | null {
     if (!raw?.trim()) return null;
-
     const p = dfParse(raw, fmt, new Date(), { locale });
     if (dfIsValid(p)) return p;
     const loose = new Date(raw);


### PR DESCRIPTION
## What

Ticket Link [here](https://jira.prod.free-now.com/browse/AUT-2298?atlOrigin=eyJpIjoiYjNhMzkyYjhhNmZiNGExMWI2MmVlNTQ1ODA1OTEyYjQiLCJwIjoiaiJ9)

It was noticed in the Dispatcher project that there can be some odd behaviour when a user uses backspace to delete numbers from the year in the date picker.

If a user has 12/12/2025 inputted in the datepicker and they then try to delete 3 numbers, the year defaults to 1920 and the user gets "stuck" unable to correct the year. This is because of JavaScript's legacy date parsing. The new Date() constructor treats years between 0 and 99 as always beginning with 19 (e.g., new Date(24, 0, 1) becomes January 1, 1924).

This PR adds `setFullYear()` to the `calendarDateToDate` function. This function correctly sets the year to the number provided, so 25 is treated as 25, not defaulted to 1925.

### Media

**Before:**

https://github.com/user-attachments/assets/8fb6cb09-2a3b-4f0c-a7a3-2b2bc4e3f864

**After:** 

https://github.com/user-attachments/assets/797978c9-44c6-44d3-af09-d51423c93f3f

