### PR TITLE
fix: remove specifying aria-label

### DIFF
--- a/src/components/experimental/ComboBox/ComboBox.tsx
+++ b/src/components/experimental/ComboBox/ComboBox.tsx
@@ -120,7 +120,7 @@ function ComboBoxComponent<T extends Record<string, unknown>>(
     });
 
     return (
-        <BaseComboBox<T> aria-label={label} shouldFocusWrap {...restProps}>
+        <BaseComboBox<T> shouldFocusWrap {...restProps}>
             {({ isInvalid }) => (
                 <>
                     <Wrapper>


### PR DESCRIPTION
<!--
Thanks for your interest in the project!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

<!-- Declarative and short sentence of what this PR accomplishes. If the PR contains visual changes, please add the design-review label to the PR -->
Remove the aria-label from the combobox

### Media

<!-- _Optionally, but highly recommended_ Depending on the impact of the change or the complexity of the contribution, choose between and image to showcase the visual changes or a Loom video describing the work you have made. -->

Before:
<img width="749" height="222" alt="Screenshot 2026-04-07 at 16 08 02" src="https://github.com/user-attachments/assets/85693b19-325f-471f-a229-c1b75c938027" />

After:
<img width="915" height="194" alt="Screenshot 2026-04-07 at 16 07 50" src="https://github.com/user-attachments/assets/1009b598-6c44-4f59-99be-cef9ea8cacc7" />



## Why

<!-- A brief explanation over why this need arise alonside a sentence with keyword to close related issue "Closes #N" or "relates #X, relates #Y" -->
`aria-label` and `aria-labelledby` stack for good reasons but in our case this lead to react-aria marking the label that it creates as `aria-labelledby` so we end up with a double message, see the screenshots above.
​

## How

<!-- Often a list of things to describe the process to accomplish this PR -->
