### PR TITLE
fix: chevron not opening dropdown on mobile

### DIFF
--- a/src/components/SelectList/SelectList.tsx
+++ b/src/components/SelectList/SelectList.tsx
@@ -130,6 +130,9 @@ const customStyles: StylesConfig = {
             marginRight: '0.5rem',
             cursor: 'pointer',
             color: getSemanticValue('foreground-neutral-default'),
+            '@media (hover: none) and (pointer: coarse)': {
+                pointerEvents: 'none'
+            },
             ...disabled
         };
     },


### PR DESCRIPTION
## What

A bug was reported where clicking on the SelectList chevron on some of freenow's projects on mobile was not opening the dropdown.

Tapping the chevron calls react-select's focusInput() to open the menu. Because the chevron icon isn't itself a native focusable target, mobile browsers clear focus once the tap gesture resolves, closing the menu right after it opens.

## How

As the SelectList box also triggers opening the menu correctly on mobile, the fix disables pointer-events on the chevron so taps fall through to the box instead (scoped to @media (hover: none) and (pointer: coarse)) so mouse clicks (and any e2e test not emulating touch) still hit the icon directly and are unaffected.

### Media

BEFORE:


https://github.com/user-attachments/assets/0582bb8c-178f-4896-bf91-1f26a5d88add



AFTER

https://github.com/user-attachments/assets/d8005083-6eb3-495a-b2a8-1dbc92c7b62e



## Why

CLOSES [SUP-53380](https://jira.prod.free-now.com/jira/software/c/projects/SUP/boards/5420?selectedIssue=SUP-53380)
​
